### PR TITLE
Add token-based authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Amadeus 0.1
+
+This project provides a FastAPI backend and an Angular frontend for the Amadeus trading bot.
+
+## Authentication
+
+All API and WebSocket endpoints require a static bearer token.
+
+1. **Configure backend** – set the token via environment variable:
+   ```bash
+   export API_TOKEN="your-secret"
+   uvicorn app.main:app --host 0.0.0.0 --port 8000
+   ```
+
+2. **Frontend** – expose the same token to the browser via `window.__TOKEN__` (and optionally `window.__API__`/`__WS__` for custom URLs). The Angular `ApiService` automatically sends the token in the `Authorization: Bearer` header and the `WsService` appends it as a `token` query parameter.
+
+3. **Making requests** – clients must include the token:
+   - HTTP: `Authorization: Bearer <token>`
+   - WebSocket: connect to `/ws?token=<token>`
+
+Changing `API_TOKEN` will invalidate existing clients.

--- a/backend/README.md
+++ b/backend/README.md
@@ -10,6 +10,11 @@ uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 ## ENV
 See `.env.example`. Defaults to shadow/paper mode.
 
+### Authentication
+- Set `API_TOKEN` to the shared secret used by clients.
+- All `/api/*` endpoints expect `Authorization: Bearer <token>`.
+- The WebSocket `/ws` requires `?token=<token>` in the URL.
+
 ## Structure
 - `api/routers/*` — REST/WS routes
 - `services/*` — Binance wrapper, MarketMaker, PairScanner, ShadowExecutor

--- a/backend/app/api/routers/ws.py
+++ b/backend/app/api/routers/ws.py
@@ -7,6 +7,7 @@ import logging
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from ...services.state import get_state
+from ...core.config import settings
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -72,6 +73,11 @@ def _subscribe(state: Any) -> tuple[asyncio.Queue, Callable[[], None]]:
 @router.websocket("/ws")
 async def ws_stream(ws: WebSocket):
     """Стрим событий в UI. Устойчив к отключениям и shutdown."""
+    token = ws.query_params.get("token")
+    if token != settings.api_token:
+        await ws.close(code=1008)
+        return
+
     await ws.accept()
     state = get_state()
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -54,6 +54,8 @@ class AppSettings(BaseSettings):
     app_reload: bool = Field(False, alias="APP_RELOAD")
     app_origins: str = Field("*", alias="APP_ORIGINS")
 
+    api_token: str = Field("secret-token", alias="API_TOKEN")
+
     binance_api_key: Optional[str] = Field(None, alias="BINANCE_API_KEY")
     binance_api_secret: Optional[str] = Field(None, alias="BINANCE_API_SECRET")
 

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
-from fastapi import Depends
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from .services.state import AppState, get_state
+from .core.config import settings
 
 def state_dep() -> AppState:
     return get_state()
+
+security = HTTPBearer(auto_error=False)
+
+def auth_dep(credentials: HTTPAuthorizationCredentials = Depends(security)) -> None:
+    token = credentials.credentials if credentials else None
+    if not token or token != settings.api_token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or missing token")

--- a/frontend/src/app/services/ws.service.ts
+++ b/frontend/src/app/services/ws.service.ts
@@ -46,8 +46,11 @@ export class WsService {
 
     private _resolveUrl(): string {
         const w: any = window as any;
-        if (w.__WS__)   return String(w.__WS__);
-        if (w.__API__)  return String(w.__API__).replace(/^http/, 'ws').replace(/\/$/, '') + '/ws';
-        return 'ws://127.0.0.1:8100/ws';
+        let base: string;
+        if (w.__WS__)   base = String(w.__WS__);
+        else if (w.__API__)  base = String(w.__API__).replace(/^http/, 'ws').replace(/\/$/, '') + '/ws';
+        else base = 'ws://127.0.0.1:8100/ws';
+        const sep = base.includes('?') ? '&' : '?';
+        return `${base}${sep}token=${encodeURIComponent(this.api.token)}`;
     }
 }


### PR DESCRIPTION
## Summary
- secure REST routers and WebSocket with bearer token dependency
- send credentials from Angular `ApiService` and `WsService`
- document authentication setup in README

## Testing
- `pytest`
- `npm test --prefix frontend` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b77412ea34832d8466d49019d818b3