### PR TITLE
Add backend test suite and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,14 @@ All API and WebSocket endpoints require a static bearer token.
    - WebSocket: connect to `/ws?token=<token>`
 
 Changing `API_TOKEN` will invalidate existing clients.
+
+## Testing
+
+1. Install dependencies:
+   ```bash
+   pip install -r backend/requirements.txt
+   ```
+2. Run the test suite:
+   ```bash
+   pytest
+   ```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import pytest
+from fastapi.testclient import TestClient
+
+# add project root to sys.path
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+# ensure API token is set before importing app
+os.environ.setdefault("API_TOKEN", "test-token")
+
+from backend.app.main import app
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+@pytest.fixture
+def auth_headers():
+    return {"Authorization": f"Bearer {os.environ['API_TOKEN']}"}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,19 @@
+from fastapi.testclient import TestClient
+
+
+def test_root_endpoint(client: TestClient):
+    resp = client.get("/")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data.get("ok") is True
+    assert "Amadeus" in data.get("name", "")
+
+
+def test_config_endpoint_requires_auth(client: TestClient, auth_headers):
+    # no auth should be unauthorized
+    resp = client.get("/api/config")
+    assert resp.status_code == 401
+
+    resp = client.get("/api/config", headers=auth_headers)
+    assert resp.status_code == 200
+    assert "cfg" in resp.json()

--- a/tests/test_risk_guards.py
+++ b/tests/test_risk_guards.py
@@ -1,0 +1,55 @@
+import time
+from backend.app.services.risk import guards
+
+
+def test_stoploss_guard(monkeypatch):
+    base = time.time()
+    monkeypatch.setattr(guards, "_now", lambda: base)
+    guard = guards.StoplossGuard({"window_minutes": 60, "max_stoploss_count": 1, "stop_duration_minutes": 60})
+    history = [guards.TradeEvent(ts=base - 10, pair="BTC", pnl=-1, stoploss_hit=True)]
+    res = guard.evaluate(history, [])
+    assert not res.allowed and "StoplossGuard" in res.reason
+    res2 = guard.evaluate(history, [])
+    assert not res2.allowed and "cooldown" in (res2.reason or "").lower()
+
+
+def test_max_drawdown_guard(monkeypatch):
+    base = time.time()
+    monkeypatch.setattr(guards, "_now", lambda: base)
+    guard = guards.MaxDrawdownGuard({"lookback_minutes": 60, "max_allowed_drawdown": 0.1, "stop_duration_minutes": 60})
+    equity_curve = [(base - 10, 100.0), (base, 80.0)]
+    res = guard.evaluate([], equity_curve)
+    assert not res.allowed and "MaxDrawdown" in res.reason
+
+
+def test_cooldown_guard(monkeypatch):
+    base = time.time()
+    monkeypatch.setattr(guards, "_now", lambda: base)
+    guard = guards.CooldownGuard({"stop_duration_minutes": 1})
+    guard.mark_trade_closed()
+    res = guard.evaluate([], [])
+    assert not res.allowed
+    monkeypatch.setattr(guards, "_now", lambda: base + 61)
+    res2 = guard.evaluate([], [])
+    assert res2.allowed
+
+
+def test_low_profit_pairs_guard(monkeypatch):
+    base = time.time()
+    monkeypatch.setattr(guards, "_now", lambda: base)
+    guard = guards.LowProfitPairsGuard({"min_trades": 2, "min_avg_pnl": 0.1, "stop_duration_minutes": 60})
+    history = [
+        guards.TradeEvent(ts=base - 10, pair="BTC", pnl=-1.0),
+        guards.TradeEvent(ts=base - 20, pair="BTC", pnl=-0.5),
+    ]
+    res = guard.evaluate_pair("BTC", history)
+    assert not res.allowed and "LowProfitPairs" in res.reason
+    res2 = guard.evaluate_pair("BTC", history)
+    assert not res2.allowed
+    monkeypatch.setattr(guards, "_now", lambda: base + 61 * 60)
+    positive_history = [
+        guards.TradeEvent(ts=base + 61 * 60 - 10, pair="BTC", pnl=1.0),
+        guards.TradeEvent(ts=base + 61 * 60 - 5, pair="BTC", pnl=1.0),
+    ]
+    res3 = guard.evaluate_pair("BTC", positive_history)
+    assert res3.allowed

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -1,0 +1,29 @@
+import time
+from backend.app.services.risk.manager import RiskManager
+
+
+def test_mdd_lock_and_unlock():
+    cfg = {"risk": {"max_drawdown_pct": 10, "dd_window_sec": 1, "stop_duration_sec": 60}}
+    rm = RiskManager(cfg)
+    t = time.time()
+    rm.on_equity(100.0, ts=t)
+    rm.on_equity(80.0, ts=t + 0.5)
+    allowed, reason = rm.can_enter()
+    assert not allowed
+    assert "MaxDrawdown lock" in reason
+    rm.unlock()
+    rm.on_equity(100.0, ts=t + 1.6)  # past window, restoring equity
+    allowed, _ = rm.can_enter()
+    assert allowed
+
+
+def test_trade_cooldown(monkeypatch):
+    cfg = {"risk": {"cooldown_sec": 10}}
+    rm = RiskManager(cfg)
+    base = time.time()
+    rm.on_trade_closed(1.0, ts=base)
+    allowed, reason = rm.can_enter()
+    assert not allowed and "Cooldown" in reason
+    monkeypatch.setattr(time, "time", lambda: base + 11)
+    allowed, _ = rm.can_enter()
+    assert allowed

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,12 @@
+from backend.app.services.utils import round_step, round_step_up
+
+
+def test_round_step():
+    assert round_step(1.2345, 0.01) == 1.23
+    assert round_step(1.2345, 0.1) == 1.2
+
+
+def test_round_step_up():
+    assert round_step_up(1.2345, 0.01) == 1.24
+    assert round_step_up(1.23, 0.01) == 1.23
+    assert round_step_up(1.23, 0) == 1.23


### PR DESCRIPTION
## Summary
- add pytest configuration and sample tests for utilities, risk manager, and risk guards
- validate FastAPI root and config endpoints with TestClient
- document test execution steps in README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b77555e218832da04922f7d4915866