### PR TITLE
feat: add environment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ All API and WebSocket endpoints require a static bearer token.
    uvicorn app.main:app --host 0.0.0.0 --port 8000
    ```
 
-2. **Frontend** – expose the same token to the browser via `window.__TOKEN__` (and optionally `window.__API__`/`__WS__` for custom URLs). The Angular `ApiService` automatically sends the token in the `Authorization: Bearer` header and the `WsService` appends it as a `token` query parameter.
+2. **Frontend** – expose the same token to the browser via `window.__TOKEN__` (and optionally `window.__WS__` for a custom WebSocket URL). The API base URL is configured in `src/environments/environment.ts`. The Angular `ApiService` automatically sends the token in the `Authorization: Bearer` header and the `WsService` appends it as a `token` query parameter.
 
 3. **Making requests** – clients must include the token:
    - HTTP: `Authorization: Bearer <token>`

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -20,6 +20,16 @@
             "assets": ["src/favicon.ico", "src/assets"],
             "styles": ["src/styles.css"],
             "scripts": []
+          },
+          "configurations": {
+            "production": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ]
+            }
           }
         },
         "serve": {

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject, Observable, of, timer } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
 
 /** Статус бота: расширен под dashboard (metrics?, cfg?) */
 export interface BotStatus {
@@ -15,7 +16,7 @@ export interface BotStatus {
 
 @Injectable({ providedIn: 'root' })
 export class ApiService {
-  private readonly baseRoot: string = ((window as any).__API__ || 'http://127.0.0.1:8100').replace(/\/$/, '');
+  private readonly baseRoot: string = environment.apiBaseUrl.replace(/\/$/, '');
   readonly api: string = this.baseRoot + '/api';
   private readonly _token: string = (window as any).__TOKEN__ || 'secret-token';
 

--- a/frontend/src/app/services/ws.service.ts
+++ b/frontend/src/app/services/ws.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NgZone } from '@angular/core';
 import { Subject } from 'rxjs';
 import { ApiService } from './api.service';
+import { environment } from '../../environments/environment';
 
 /**
  * WS-клиент с авто-реконнектом.
@@ -48,8 +49,7 @@ export class WsService {
         const w: any = window as any;
         let base: string;
         if (w.__WS__)   base = String(w.__WS__);
-        else if (w.__API__)  base = String(w.__API__).replace(/^http/, 'ws').replace(/\/$/, '') + '/ws';
-        else base = 'ws://127.0.0.1:8100/ws';
+        else base = environment.apiBaseUrl.replace(/^http/, 'ws').replace(/\/$/, '') + '/ws';
         const sep = base.includes('?') ? '&' : '?';
         return `${base}${sep}token=${encodeURIComponent(this.api.token)}`;
     }

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  apiBaseUrl: 'http://127.0.0.1:8100',
+};

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiBaseUrl: 'http://127.0.0.1:8100',
+};

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -8,8 +8,7 @@
     <link rel="icon" type="image/x-icon" href="favicon.ico">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
     <script>
-        // жёстко указываем бек на 127.0.0.1:8100
-        window.__API__ = 'http://127.0.0.1:8100';
+        // жёстко указываем WS на 127.0.0.1:8100
         window.__WS__  = 'ws://127.0.0.1:8100/ws';
     </script>
 </head>


### PR DESCRIPTION
## Summary
- add Angular environment files with api base URL
- use environment apiBaseUrl in ApiService and WebSocket service
- configure production file replacement and remove window.__API__ usage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b77872ed58832db9fcf72bcd6c8e61