### PR TITLE
feat: enforce strict typing for config and risk views

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -1,7 +1,8 @@
 import { Component, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AppMaterialModule } from '../../app.module';
-import { ApiService, BotStatus } from '../../services/api.service';
+import { ApiService } from '../../services/api.service';
+import { BotStatus } from '../../models';
 import { WsService } from '../../services/ws.service';
 import { Subscription } from 'rxjs';
 import { EquitySparklineComponent } from '../equity-sparkline/equity-sparkline.component'; // ⬅️ импорт спарклайна

--- a/frontend/src/app/components/history/history.component.ts
+++ b/frontend/src/app/components/history/history.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AppMaterialModule } from '../../app.module';
 import { ApiService } from '../../services/api.service';
+import { HistoryResponse, HistoryStats, OrderHistoryItem, TradeHistoryItem } from '../../models';
 
 @Component({
     selector: 'app-history',
@@ -11,11 +12,11 @@ import { ApiService } from '../../services/api.service';
     styleUrls: ['./history.component.css']
 })
 export class HistoryComponent {
-    orders: any[] = [];
-    trades: any[] = [];
+    orders: OrderHistoryItem[] = [];
+    trades: TradeHistoryItem[] = [];
     loadingO = false;
     loadingT = false;
-    stats: any = {};
+    stats: HistoryStats = { orders: 0, trades: 0 };
 
     constructor(private api: ApiService) {}
 
@@ -26,13 +27,13 @@ export class HistoryComponent {
     refreshAll() {
         this.refreshOrders();
         this.refreshTrades();
-        this.api.historyStats().subscribe(s => this.stats = s || {});
+        this.api.historyStats().subscribe(s => this.stats = s);
     }
 
     refreshOrders() {
         this.loadingO = true;
         this.api.historyOrders(200, 0).subscribe({
-            next: (res: any) => { this.orders = res?.items || []; this.loadingO = false; },
+            next: (res: HistoryResponse<OrderHistoryItem>) => { this.orders = res.items ?? []; this.loadingO = false; },
             error: () => { this.loadingO = false; }
         });
     }
@@ -40,7 +41,7 @@ export class HistoryComponent {
     refreshTrades() {
         this.loadingT = true;
         this.api.historyTrades(200, 0).subscribe({
-            next: (res: any) => { this.trades = res?.items || []; this.loadingT = false; },
+            next: (res: HistoryResponse<TradeHistoryItem>) => { this.trades = res.items ?? []; this.loadingT = false; },
             error: () => { this.loadingT = false; }
         });
     }
@@ -51,6 +52,6 @@ export class HistoryComponent {
     }
 
     clear(kind: 'orders'|'trades'|'all') {
-        this.api.historyClear(kind).subscribe(_ => this.refreshAll());
+        this.api.historyClear(kind).subscribe(() => this.refreshAll());
     }
 }

--- a/frontend/src/app/components/risk-widget/risk-widget.component.ts
+++ b/frontend/src/app/components/risk-widget/risk-widget.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AppMaterialModule } from '../../app.module';
 import { ApiService } from '../../services/api.service';
+import { RiskStatus } from '../../models';
 
 @Component({
     selector: 'app-risk-widget',
@@ -12,7 +13,7 @@ import { ApiService } from '../../services/api.service';
 })
 export class RiskWidgetComponent {
     loading = true;
-    data: any = null;
+    data: RiskStatus | null = null;
     err = '';
 
     constructor(private api: ApiService) {}
@@ -22,12 +23,12 @@ export class RiskWidgetComponent {
     refresh() {
         this.loading = true;
         this.api.getRiskStatus().subscribe({
-            next: (d: any) => { this.data = d; this.err = ''; this.loading = false; },
-            error: (e) => { this.err = String(e?.message || e); this.loading = false; }
+            next: (d: RiskStatus) => { this.data = d; this.err = ''; this.loading = false; },
+            error: (e: unknown) => { this.err = String((e as { message?: string })?.message || e); this.loading = false; }
         });
     }
 
     unlock() {
-        this.api.unlockRisk().subscribe(_ => this.refresh());
+        this.api.unlockRisk().subscribe(() => this.refresh());
     }
 }

--- a/frontend/src/app/models.ts
+++ b/frontend/src/app/models.ts
@@ -1,0 +1,87 @@
+export interface RiskStatus {
+  locked: boolean;
+  max_drawdown_pct?: number;
+  cooldown_left_sec?: number;
+  min_trades_for_dd?: number;
+  [key: string]: unknown;
+}
+
+export interface Config {
+  api?: {
+    paper?: boolean;
+    shadow?: boolean;
+    autostart?: boolean;
+    [key: string]: unknown;
+  };
+  shadow?: {
+    rest_base?: string;
+    ws_base?: string;
+    [key: string]: unknown;
+  };
+  ui?: {
+    chart?: string;
+    theme?: string;
+    [key: string]: unknown;
+  };
+  risk?: {
+    max_drawdown_pct?: number;
+    dd_window_sec?: number;
+    stop_duration_sec?: number;
+    cooldown_sec?: number;
+    min_trades_for_dd?: number;
+    [key: string]: unknown;
+  };
+  strategy?: {
+    symbol?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export interface ConfigResponse {
+  cfg: Config;
+  [key: string]: unknown;
+}
+
+export type ConfigGetResponse = Config | ConfigResponse;
+
+export interface HistoryStats {
+  orders: number;
+  trades: number;
+}
+
+export interface OrderHistoryItem {
+  id: number;
+  ts: number;
+  event: string;
+  symbol: string;
+  side: string;
+  type: string;
+  price: number | null;
+  qty: number | null;
+  status: string;
+}
+
+export interface TradeHistoryItem {
+  id: number;
+  ts: number;
+  type: string;
+  symbol: string;
+  side: string;
+  price: number | null;
+  qty: number | null;
+  pnl: number | null;
+}
+
+export interface HistoryResponse<T> {
+  items: T[];
+}
+
+export interface BotStatus {
+  running: boolean;
+  symbol?: string;
+  equity?: number;
+  ts?: number;
+  metrics?: Record<string, unknown>;
+  cfg?: Config;
+}

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject, Observable, of, timer } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
 import {
   BotStatus,
   Config,
@@ -20,7 +21,7 @@ import {
 @Injectable({ providedIn: 'root' })
 export class ApiService {
   private readonly win = window as unknown as { __API__?: string; __TOKEN__?: string };
-  private readonly baseRoot: string = (this.win.__API__ || 'http://127.0.0.1:8100').replace(/\/$/, '');
+  private readonly baseRoot: string = (this.win.__API__ || environment.apiBaseUrl || 'http://127.0.0.1:8100').replace(/\/$/, '');
   readonly api: string = this.baseRoot + '/api';
   private readonly _token: string = this.win.__TOKEN__ || 'secret-token';
 

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  apiBaseUrl: 'http://127.0.0.1:8100'
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -12,6 +12,7 @@
     "target": "ES2022",
     "module": "ES2022",
     "useDefineForClassFields": false,
-    "types": []
+    "types": [],
+    "strict": true
   }
 }


### PR DESCRIPTION
## Summary
- add shared interfaces for risk status, configuration, and history records
- replace `any` in API service and UI components with these types
- enable TypeScript `strict` mode

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b77927caf4832da72b0da9508c713e