### PR TITLE
Add UI, feature, risk and history configuration sections

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -22,6 +22,28 @@ See `.env.example`. Defaults to shadow/paper mode.
 - `models/schemas.py` — Pydantic schemas
 - `services/state.py` — application state
 
+## Configuration
+Runtime options are read from `config.yaml` (see `config.example.yaml` for the full schema).
+The following sections were added:
+
+```yaml
+ui:
+  chart: tv
+  theme: dark
+features:
+  risk_protections: true
+  market_widget_feed: true
+risk:
+  max_drawdown_pct: 10.0
+  dd_window_sec: 86400
+  stop_duration_sec: 43200
+  cooldown_sec: 1800
+  min_trades_for_dd: 0
+history:
+  db_path: data/history.db
+  retention_days: 365
+```
+
 ## Endpoints
 - `POST /bot/start`
 - `POST /bot/stop`

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -20,6 +20,33 @@ class ShadowConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class UiConfig(BaseModel):
+    chart: str = "tv"
+    theme: str = "dark"
+    model_config = ConfigDict(extra="forbid")
+
+
+class FeaturesConfig(BaseModel):
+    risk_protections: bool = True
+    market_widget_feed: bool = True
+    model_config = ConfigDict(extra="forbid")
+
+
+class RiskConfig(BaseModel):
+    max_drawdown_pct: float = 10.0
+    dd_window_sec: int = 24 * 3600
+    stop_duration_sec: int = 12 * 3600
+    cooldown_sec: int = 30 * 60
+    min_trades_for_dd: int = 0
+    model_config = ConfigDict(extra="forbid")
+
+
+class HistoryConfig(BaseModel):
+    db_path: str = "data/history.db"
+    retention_days: int = 365
+    model_config = ConfigDict(extra="forbid")
+
+
 class ScannerScoreConfig(BaseModel):
     w_spread: float = 1.0
     w_vol: float = 0.3
@@ -74,6 +101,10 @@ class StrategyConfig(BaseModel):
 class RuntimeConfig(BaseModel):
     api: ApiConfig = ApiConfig()
     shadow: ShadowConfig = ShadowConfig()
+    ui: UiConfig = UiConfig()
+    features: FeaturesConfig = FeaturesConfig()
+    risk: RiskConfig = RiskConfig()
+    history: HistoryConfig = HistoryConfig()
     scanner: ScannerConfig = ScannerConfig()
     strategy: StrategyConfig = StrategyConfig()
     model_config = ConfigDict(extra="forbid")

--- a/backend/config.example.yaml
+++ b/backend/config.example.yaml
@@ -1,0 +1,60 @@
+api:
+  paper: true
+shadow:
+  enabled: true
+  alpha: 0.85
+  latency_ms: 120
+  post_only_reject: true
+  market_slippage_bps: 1.0
+ui:
+  chart: tv
+  theme: dark
+features:
+  risk_protections: true
+  market_widget_feed: true
+risk:
+  max_drawdown_pct: 10.0
+  dd_window_sec: 86400
+  stop_duration_sec: 43200
+  cooldown_sec: 1800
+  min_trades_for_dd: 0
+history:
+  db_path: data/history.db
+  retention_days: 365
+scanner:
+  enabled: false
+  quote: USDT
+  min_price: 0.0001
+  min_vol_usdt_24h: 3000000
+  top_by_volume: 120
+  max_pairs: 60
+  min_spread_bps: 5.0
+  vol_bars: 0
+  score:
+    w_spread: 1.0
+    w_vol: 0.3
+  whitelist: []
+  blacklist: []
+strategy:
+  symbol: BNBUSDT
+  quote_size: 10.0
+  target_pct: 0.5
+  min_spread_pct: 0.0
+  cancel_timeout: 10.0
+  reorder_interval: 1.0
+  depth_level: 5
+  maker_fee_pct: 0.1
+  taker_fee_pct: 0.1
+  econ:
+    min_net_pct: 0.1
+  post_only: true
+  aggressive_take: false
+  aggressive_bps: 0.0
+  allow_short: false
+  status_poll_interval: 2.0
+  stats_interval: 30.0
+  ws_timeout: 2.0
+  bootstrap_on_idle: true
+  rest_bootstrap_interval: 3.0
+  plan_log_interval: 5.0
+  paper_cash: 1000

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -5,8 +5,14 @@ from backend.app.core.config import AppSettings, RuntimeConfig
 
 def test_load_yaml_defaults(tmp_path):
     cfg_file = tmp_path / "config.yaml"
-    # Write minimal config with only some overrides
-    cfg_data = {"api": {"paper": False}, "strategy": {"symbol": "ETHUSDT"}}
+    cfg_data = {
+        "api": {"paper": False},
+        "strategy": {"symbol": "ETHUSDT"},
+        "ui": {"theme": "light"},
+        "features": {"risk_protections": False},
+        "risk": {"max_drawdown_pct": 5},
+        "history": {"db_path": "test.db"},
+    }
     cfg_file.write_text(yaml.safe_dump(cfg_data))
 
     s = AppSettings(app_config_file=str(cfg_file))
@@ -14,13 +20,27 @@ def test_load_yaml_defaults(tmp_path):
 
     assert s.runtime_cfg["api"]["paper"] is False
     assert s.runtime_cfg["strategy"]["symbol"] == "ETHUSDT"
-    # default from model
+    assert s.runtime_cfg["ui"]["theme"] == "light"
+    assert s.runtime_cfg["ui"]["chart"] == "tv"
+    assert s.runtime_cfg["features"]["risk_protections"] is False
+    assert s.runtime_cfg["features"]["market_widget_feed"] is True
+    assert s.runtime_cfg["risk"]["max_drawdown_pct"] == 5
+    assert s.runtime_cfg["risk"]["cooldown_sec"] == 1800
+    assert s.runtime_cfg["history"]["db_path"] == "test.db"
+    assert s.runtime_cfg["history"]["retention_days"] == 365
     assert s.runtime_cfg["shadow"]["enabled"] is True
 
 
-def test_load_yaml_invalid_field(tmp_path):
+@pytest.mark.parametrize("bad_section", [
+    {"strategy": {"unknown": 1}},
+    {"ui": {"unknown": 1}},
+    {"features": {"unknown": 1}},
+    {"risk": {"unknown": 1}},
+    {"history": {"unknown": 1}},
+])
+def test_load_yaml_invalid_field(tmp_path, bad_section):
     cfg_file = tmp_path / "config.yaml"
-    cfg_file.write_text(yaml.safe_dump({"strategy": {"unknown": 1}}))
+    cfg_file.write_text(yaml.safe_dump(bad_section))
     s = AppSettings(app_config_file=str(cfg_file))
     with pytest.raises(ValueError):
         s.load_yaml()


### PR DESCRIPTION
## Summary
- add UiConfig, FeaturesConfig, RiskConfig and HistoryConfig models
- expose new sections on RuntimeConfig and provide sample YAML
- expand config validation tests for new sections

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b785399980832db3a0f88d1b301d77