### PR TITLE
feat: add autostart and shadow api flags

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -27,6 +27,10 @@ Runtime options are read from `config.yaml` (see `config.example.yaml` for the f
 The following sections were added:
 
 ```yaml
+api:
+  paper: true
+  shadow: false
+  autostart: false
 ui:
   chart: tv
   theme: dark

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -8,6 +8,8 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class ApiConfig(BaseModel):
     paper: bool = True
+    autostart: bool = False
+    shadow: bool = False
     model_config = ConfigDict(extra="forbid")
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -66,10 +66,11 @@ async def on_startup():
     """
     state = get_state()
     state.cfg = settings.runtime_cfg or {}
-    log.info("Config синхронизирован: ui.chart=%s, api.paper=%s, api.shadow=%s",
+    log.info("Config синхронизирован: ui.chart=%s, api.paper=%s, api.shadow=%s, api.autostart=%s",
              state.cfg.get("ui", {}).get("chart"),
              state.cfg.get("api", {}).get("paper"),
-             state.cfg.get("api", {}).get("shadow"))
+             state.cfg.get("api", {}).get("shadow"),
+             state.cfg.get("api", {}).get("autostart"))
 
     # НЕ автозапуск по умолчанию
     autostart = bool(state.cfg.get("api", {}).get("autostart", False))

--- a/backend/app/services/binance_client.py
+++ b/backend/app/services/binance_client.py
@@ -231,7 +231,7 @@ class BinanceAsync:
             api_key: Optional[str],
             api_secret: Optional[str],
             paper: bool = True,
-            shadow: bool = True,
+            shadow: bool = False,
             shadow_opts: Optional[Dict[str, Any]] = None,
             events_cb: Optional[Callable[[Dict[str, Any]], Any]] = None,
             state: Optional["AppState"] = None,

--- a/backend/app/services/state.py
+++ b/backend/app/services/state.py
@@ -215,7 +215,7 @@ class AppState:
         shadow_cfg = (cfg.get("shadow") or {})
 
         paper = bool(api.get("paper", True))
-        shadow_en = bool(api.get("shadow", True))
+        shadow_en = bool(api.get("shadow", False))
 
         self._ensure_risk()
         self.history = HistoryStore()

--- a/backend/config.example.yaml
+++ b/backend/config.example.yaml
@@ -1,5 +1,7 @@
 api:
   paper: true
+  shadow: false
+  autostart: false
 shadow:
   enabled: true
   alpha: 0.85

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -19,6 +19,8 @@ def test_load_yaml_defaults(tmp_path):
     s.load_yaml()
 
     assert s.runtime_cfg["api"]["paper"] is False
+    assert s.runtime_cfg["api"]["autostart"] is False
+    assert s.runtime_cfg["api"]["shadow"] is False
     assert s.runtime_cfg["strategy"]["symbol"] == "ETHUSDT"
     assert s.runtime_cfg["ui"]["theme"] == "light"
     assert s.runtime_cfg["ui"]["chart"] == "tv"


### PR DESCRIPTION
## Summary
- extend API config with `autostart` and `shadow` booleans
- log and default these flags in startup/runtime
- document new config options and expand tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b786eb14a0832dad1d816f5ae66890