### PR TITLE
feat: add loop sleep config

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -48,6 +48,9 @@ history:
   retention_days: 365
 ```
 
+The `strategy` section includes a `loop_sleep` option to configure the pause in
+seconds between each iteration of the market-making loop. The default is `0.2`.
+
 ## Endpoints
 - `POST /bot/start`
 - `POST /bot/stop`

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -82,6 +82,7 @@ class StrategyConfig(BaseModel):
     min_spread_pct: float = 0.0
     cancel_timeout: float = 10.0
     reorder_interval: float = 1.0
+    loop_sleep: float = 0.2
     depth_level: int = 5
     maker_fee_pct: float = 0.1
     taker_fee_pct: float = 0.1

--- a/backend/config.example.yaml
+++ b/backend/config.example.yaml
@@ -44,6 +44,7 @@ strategy:
   min_spread_pct: 0.0
   cancel_timeout: 10.0
   reorder_interval: 1.0
+  loop_sleep: 0.2
   depth_level: 5
   maker_fee_pct: 0.1
   taker_fee_pct: 0.1

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -22,6 +22,7 @@ def test_load_yaml_defaults(tmp_path):
     assert s.runtime_cfg["api"]["autostart"] is False
     assert s.runtime_cfg["api"]["shadow"] is False
     assert s.runtime_cfg["strategy"]["symbol"] == "ETHUSDT"
+    assert s.runtime_cfg["strategy"]["loop_sleep"] == 0.2
     assert s.runtime_cfg["ui"]["theme"] == "light"
     assert s.runtime_cfg["ui"]["chart"] == "tv"
     assert s.runtime_cfg["features"]["risk_protections"] is False
@@ -31,6 +32,14 @@ def test_load_yaml_defaults(tmp_path):
     assert s.runtime_cfg["history"]["db_path"] == "test.db"
     assert s.runtime_cfg["history"]["retention_days"] == 365
     assert s.runtime_cfg["shadow"]["enabled"] is True
+
+
+def test_loop_sleep_override(tmp_path):
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text(yaml.safe_dump({"strategy": {"loop_sleep": 0.5}}))
+    s = AppSettings(app_config_file=str(cfg_file))
+    s.load_yaml()
+    assert s.runtime_cfg["strategy"]["loop_sleep"] == 0.5
 
 
 @pytest.mark.parametrize("bad_section", [


### PR DESCRIPTION
## Summary
- allow configuring strategy loop sleep interval
- document `strategy.loop_sleep` and include it in config example
- test default and custom `loop_sleep` values

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b788913130832d9eefa8c356508202