### PR TITLE
feat: add aggressive taker mode to market maker

### DIFF
--- a/tests/test_market_maker_aggressive.py
+++ b/tests/test_market_maker_aggressive.py
@@ -1,0 +1,62 @@
+import asyncio
+import pytest
+from backend.app.services.market_maker import MarketMaker
+
+
+class DummyClient:
+    pass
+
+
+def test_aggressive_take_places_taker_orders():
+    events = []
+    cfg = {
+        "strategy": {
+            "symbol": "TESTUSDT",
+            "quote_size": 10.0,
+            "min_spread_pct": 1.0,
+            "reorder_interval": 0.0,
+            "aggressive_take": True,
+            "aggressive_bps": 1000.0,
+        }
+    }
+    mm = MarketMaker(cfg, DummyClient(), lambda evt: events.append(evt))
+    mm.best_bid = 100.0
+    mm.best_ask = 100.05
+    asyncio.run(mm._step_once())
+    buys = [o for o in mm.orders.values() if o.side == "BUY" and o.status == "NEW"]
+    sells = [o for o in mm.orders.values() if o.side == "SELL" and o.status == "NEW"]
+    assert buys and sells
+    assert buys[0].price == pytest.approx(mm.best_ask)
+    assert sells[0].price == pytest.approx(mm.best_bid)
+    taker_quote = mm.quote_size * mm.aggressive_bps / 10000.0
+    assert buys[0].qty == pytest.approx(mm._round_qty(taker_quote / mm.best_ask))
+    assert sells[0].qty == pytest.approx(mm._round_qty(taker_quote / mm.best_bid))
+    asyncio.run(mm._step_once())
+    assert all(o.status == "FILLED" for o in buys + sells)
+
+
+def test_aggressive_take_runtime_toggle():
+    events = []
+    cfg = {
+        "strategy": {
+            "symbol": "TESTUSDT",
+            "quote_size": 10.0,
+            "min_spread_pct": 1.0,
+            "reorder_interval": 0.0,
+            "aggressive_take": True,
+            "aggressive_bps": 1000.0,
+        }
+    }
+    mm = MarketMaker(cfg, DummyClient(), lambda evt: events.append(evt))
+    mm.best_bid = 100.0
+    mm.best_ask = 100.05
+    asyncio.run(mm._step_once())
+    assert any(o.side == "BUY" and o.price == pytest.approx(mm.best_ask) and o.status == "NEW" for o in mm.orders.values())
+    mm.cfg["strategy"]["aggressive_take"] = False
+    mm._last_reorder_ts = 0.0
+    asyncio.run(mm._step_once())
+    new_orders = [o for o in mm.orders.values() if o.status == "NEW"]
+    assert any(o.side == "BUY" and o.price == pytest.approx(mm.best_bid) for o in new_orders)
+    assert any(o.side == "SELL" and o.price == pytest.approx(mm.best_ask) for o in new_orders)
+    assert not any(o.side == "BUY" and o.price == pytest.approx(mm.best_ask) for o in new_orders)
+    assert not any(o.side == "SELL" and o.price == pytest.approx(mm.best_bid) for o in new_orders)


### PR DESCRIPTION
## Summary
- support runtime-configurable aggressive taker orders in market maker
- test aggressive taker placement and runtime toggling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b78d342264832d93a50d7b87024907