### PR TITLE
refactor: add strategy abstraction

### DIFF
--- a/backend/app/api/routers/ws.py
+++ b/backend/app/api/routers/ws.py
@@ -102,7 +102,9 @@ async def ws_stream(ws: WebSocket):
         await _safe_send(ws, {"type": "hello", "version": "1.0"})
         try:
             cfg = getattr(state, "cfg", {}) or {}
-            symbol = (cfg.get("strategy") or {}).get("symbol")
+            strat = (cfg.get("strategy") or {})
+            name = strat.get("name")
+            symbol = (strat.get(name, {}) or {}).get("symbol")
             await _safe_send(ws, {
                 "type": "status",
                 "running": bool(state.is_running()) if hasattr(state, "is_running") else False,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -75,7 +75,7 @@ class StrategyEconConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class StrategyConfig(BaseModel):
+class MarketMakerStrategyConfig(BaseModel):
     symbol: str = "BNBUSDT"
     quote_size: float = 10.0
     target_pct: float = 0.5
@@ -98,6 +98,13 @@ class StrategyConfig(BaseModel):
     rest_bootstrap_interval: float = 3.0
     plan_log_interval: float = 5.0
     paper_cash: float = 1000
+    model_config = ConfigDict(extra="forbid")
+
+
+class StrategyConfig(BaseModel):
+    name: str = "market_maker"
+    market_maker: MarketMakerStrategyConfig = MarketMakerStrategyConfig()
+    trend_follow: Dict[str, Any] = Field(default_factory=dict)
     model_config = ConfigDict(extra="forbid")
 
 

--- a/backend/app/services/base_strategy.py
+++ b/backend/app/services/base_strategy.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class BaseStrategy(ABC):
+    """Abstract trading strategy interface."""
+
+    def __init__(self, cfg: dict[str, Any], client_wrapper: Any, events_cb: Any) -> None:
+        self.cfg = cfg
+        self.client_wrap = client_wrapper
+        self.events_cb = events_cb
+
+    @abstractmethod
+    async def start(self) -> None:
+        """Initialize resources for the strategy."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def stop(self) -> None:
+        """Cleanup resources before shutdown."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def step(self) -> None:
+        """Execute one iteration of the strategy."""
+        raise NotImplementedError

--- a/backend/app/services/state.py
+++ b/backend/app/services/state.py
@@ -28,7 +28,7 @@ class AppState:
 
         # внешние сервисы/модули (лениво создаются при старте бота)
         self.binance = None   # type: ignore
-        self.mm = None        # type: ignore
+        self.strategy = None  # type: ignore
         self.history = None   # type: ignore
 
         # риск
@@ -206,12 +206,14 @@ class AppState:
             return
 
         from .binance_client import BinanceAsync
-        from .market_maker import MarketMaker
+        from .market_maker_strategy import MarketMakerStrategy
         from .history import HistoryStore
 
         cfg = self.cfg
         api = (cfg.get("api") or {})
         strategy = (cfg.get("strategy") or {})
+        strategy_name = str(strategy.get("name") or "market_maker")
+        strategy_cfg = strategy.get(strategy_name, {})
         shadow_cfg = (cfg.get("shadow") or {})
 
         paper = bool(api.get("paper", True))
@@ -231,10 +233,17 @@ class AppState:
             state=self,
         )
 
-        self.mm = MarketMaker(cfg, client_wrapper=self.binance, events_cb=self.on_event)
+        if strategy_name == "market_maker":
+            self.strategy = MarketMakerStrategy(
+                cfg, client_wrapper=self.binance, events_cb=self.on_event
+            )
+        else:
+            raise ValueError(f"Unknown strategy: {strategy_name}")
+
+        await self.strategy.start()
 
         if self.market_widget_feed_enabled:
-            sym = str(strategy.get("symbol") or "BTCUSDT")
+            sym = str(strategy_cfg.get("symbol") or "BTCUSDT")
             self._market_task = asyncio.create_task(self._market_widget_loop(sym))
 
         self._task = asyncio.create_task(self._run_loop())
@@ -263,15 +272,22 @@ class AppState:
             finally:
                 self._market_task = None
 
+        if self.strategy is not None:
+            try:
+                await self.strategy.stop()
+            except Exception:
+                logger.exception("Strategy stop failed")
         await self._close_binance()
-        self.mm = None
+        self.strategy = None
         self.broadcast("diag", text="STOPPED")
         self.broadcast_status()
         logger.info("bot stopped")
 
     async def _run_loop(self) -> None:
         cfg = self.cfg
-        loop_sleep = float((cfg.get("strategy") or {}).get("loop_sleep", 0.2))
+        strat = (cfg.get("strategy") or {})
+        name = str(strat.get("name") or "market_maker")
+        loop_sleep = float((strat.get(name) or {}).get("loop_sleep", 0.2))
         stats_interval = 1.0
         last_stats = time.time()
 
@@ -280,10 +296,10 @@ class AppState:
         try:
             while True:
                 try:
-                    if hasattr(self.mm, "step"):
-                        await self.mm.step()
-                    elif hasattr(self.mm, "run"):
-                        await self.mm.run()
+                    if hasattr(self.strategy, "step"):
+                        await self.strategy.step()
+                    elif hasattr(self.strategy, "run"):
+                        await self.strategy.run()
                     else:
                         await asyncio.sleep(loop_sleep)
                 except Exception as e:
@@ -293,7 +309,7 @@ class AppState:
                         tb = tb[-5000:]
                     for line in tb.splitlines():
                         self.broadcast("diag", text=line)
-                    logger.exception("mm loop error: %s", e)
+                    logger.exception("strategy loop error: %s", e)
                     await asyncio.sleep(0.5)
 
                 now = time.time()
@@ -496,12 +512,24 @@ class AppState:
 
     def status(self) -> BotStatus:
         m: Dict[str, Any] = {"ws_clients": len(self._clients)}
-        if self.mm is not None:
-            for key in ("ticks_total", "orders_total", "orders_active", "orders_filled", "orders_expired"):
-                val = getattr(self.mm, key, None)
+        if self.strategy is not None:
+            for key in (
+                "ticks_total",
+                "orders_total",
+                "orders_active",
+                "orders_filled",
+                "orders_expired",
+            ):
+                val = getattr(self.strategy, key, None)
                 if val is not None:
                     m[key] = val
-        sym = getattr(self.mm, "symbol", None) if self.mm else (self.cfg.get("strategy") or {}).get("symbol")
+        strat = (self.cfg.get("strategy") or {})
+        name = strat.get("name")
+        sym = (
+            getattr(self.strategy, "symbol", None)
+            if self.strategy
+            else (strat.get(name, {}) or {}).get("symbol")
+        )
         return BotStatus(running=self.is_running(), symbol=sym, metrics=m, cfg=self.cfg)
 
 

--- a/backend/config.example.yaml
+++ b/backend/config.example.yaml
@@ -38,26 +38,30 @@ scanner:
   whitelist: []
   blacklist: []
 strategy:
-  symbol: BNBUSDT
-  quote_size: 10.0
-  target_pct: 0.5
-  min_spread_pct: 0.0
-  cancel_timeout: 10.0
-  reorder_interval: 1.0
-  loop_sleep: 0.2
-  depth_level: 5
-  maker_fee_pct: 0.1
-  taker_fee_pct: 0.1
-  econ:
-    min_net_pct: 0.1
-  post_only: true
-  aggressive_take: false
-  aggressive_bps: 0.0
-  allow_short: false
-  status_poll_interval: 2.0
-  stats_interval: 30.0
-  ws_timeout: 2.0
-  bootstrap_on_idle: true
-  rest_bootstrap_interval: 3.0
-  plan_log_interval: 5.0
-  paper_cash: 1000
+  name: market_maker
+  market_maker:
+    symbol: BNBUSDT
+    quote_size: 10.0
+    target_pct: 0.5
+    min_spread_pct: 0.0
+    cancel_timeout: 10.0
+    reorder_interval: 1.0
+    loop_sleep: 0.2
+    depth_level: 5
+    maker_fee_pct: 0.1
+    taker_fee_pct: 0.1
+    econ:
+      min_net_pct: 0.1
+    post_only: true
+    aggressive_take: false
+    aggressive_bps: 0.0
+    allow_short: false
+    status_poll_interval: 2.0
+    stats_interval: 30.0
+    ws_timeout: 2.0
+    bootstrap_on_idle: true
+    rest_bootstrap_interval: 3.0
+    plan_log_interval: 5.0
+    paper_cash: 1000
+  trend_follow:
+    enabled: false

--- a/tests/test_market_maker_aggressive.py
+++ b/tests/test_market_maker_aggressive.py
@@ -1,6 +1,6 @@
 import asyncio
 import pytest
-from backend.app.services.market_maker import MarketMaker
+from backend.app.services.market_maker_strategy import MarketMakerStrategy
 
 
 class DummyClient:
@@ -11,15 +11,18 @@ def test_aggressive_take_places_taker_orders():
     events = []
     cfg = {
         "strategy": {
-            "symbol": "TESTUSDT",
-            "quote_size": 10.0,
-            "min_spread_pct": 1.0,
-            "reorder_interval": 0.0,
-            "aggressive_take": True,
-            "aggressive_bps": 1000.0,
+            "name": "market_maker",
+            "market_maker": {
+                "symbol": "TESTUSDT",
+                "quote_size": 10.0,
+                "min_spread_pct": 1.0,
+                "reorder_interval": 0.0,
+                "aggressive_take": True,
+                "aggressive_bps": 1000.0,
+            },
         }
     }
-    mm = MarketMaker(cfg, DummyClient(), lambda evt: events.append(evt))
+    mm = MarketMakerStrategy(cfg, DummyClient(), lambda evt: events.append(evt))
     mm.best_bid = 100.0
     mm.best_ask = 100.05
     asyncio.run(mm._step_once())
@@ -39,20 +42,23 @@ def test_aggressive_take_runtime_toggle():
     events = []
     cfg = {
         "strategy": {
-            "symbol": "TESTUSDT",
-            "quote_size": 10.0,
-            "min_spread_pct": 1.0,
-            "reorder_interval": 0.0,
-            "aggressive_take": True,
-            "aggressive_bps": 1000.0,
+            "name": "market_maker",
+            "market_maker": {
+                "symbol": "TESTUSDT",
+                "quote_size": 10.0,
+                "min_spread_pct": 1.0,
+                "reorder_interval": 0.0,
+                "aggressive_take": True,
+                "aggressive_bps": 1000.0,
+            },
         }
     }
-    mm = MarketMaker(cfg, DummyClient(), lambda evt: events.append(evt))
+    mm = MarketMakerStrategy(cfg, DummyClient(), lambda evt: events.append(evt))
     mm.best_bid = 100.0
     mm.best_ask = 100.05
     asyncio.run(mm._step_once())
     assert any(o.side == "BUY" and o.price == pytest.approx(mm.best_ask) and o.status == "NEW" for o in mm.orders.values())
-    mm.cfg["strategy"]["aggressive_take"] = False
+    mm.cfg["strategy"]["market_maker"]["aggressive_take"] = False
     mm._last_reorder_ts = 0.0
     asyncio.run(mm._step_once())
     new_orders = [o for o in mm.orders.values() if o.status == "NEW"]


### PR DESCRIPTION
## Summary
- introduce `BaseStrategy` abstraction and port existing market maker to `MarketMakerStrategy`
- select trading strategy via `strategy.name` in application state
- restructure configuration and tests to group strategy parameters under `strategy.market_maker`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b78f629940832dba6ee6e1c62b6def