### PR TITLE
feat: add pair scanner integration and UI

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -3,6 +3,11 @@
     <div class="brand">{{ title }}</div>
     <div class="spacer"></div>
 
+    <!-- Scanner -->
+    <button mat-icon-button aria-label="Scanner" (click)="openScanner()" matTooltip="Сканер пар">
+        <mat-icon>search</mat-icon>
+    </button>
+
     <!-- История -->
     <button mat-icon-button aria-label="История" (click)="openHistory()" matTooltip="История / Live">
         <mat-icon>history</mat-icon>
@@ -216,6 +221,20 @@
             </div>
         </div>
 
+    </div>
+</div>
+
+<!-- ======= OVERLAY: SCANNER ======= -->
+<div class="overlay" *ngIf="showScanner" (click)="closeOverlays()">
+    <div class="panel panel-wide" (click)="$event.stopPropagation()">
+        <div class="panel-head">
+            <div class="title">Сканер</div>
+            <span class="spacer"></span>
+            <button mat-icon-button (click)="closeOverlays()"><mat-icon>close</mat-icon></button>
+        </div>
+        <div class="panel-body">
+            <app-scanner></app-scanner>
+        </div>
     </div>
 </div>
 

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -32,6 +32,7 @@ import { TvLightweightComponent } from './components/tv-lightweight/tv-lightweig
 import { HistoryComponent } from './components/history/history.component';
 import { OrdersWidgetComponent } from './components/orders-widget/orders-widget.component';
 import { ConfigComponent } from './components/config/config.component';
+import { ScannerComponent } from './components/scanner/scanner.component';
 
 type Theme = 'dark' | 'light';
 type ChartMode = 'tv' | 'lightweight' | 'none';
@@ -50,7 +51,7 @@ interface DbRow { event: string; symbol: string; side: string; type: string; pri
     // Наши компоненты
     ControlsComponent, DashboardComponent, LogsComponent, GuardsComponent,
     TvAdvancedComponent, TvLightweightComponent,
-    HistoryComponent, OrdersWidgetComponent, ConfigComponent
+    HistoryComponent, OrdersWidgetComponent, ConfigComponent, ScannerComponent
   ],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
@@ -61,6 +62,7 @@ export class AppComponent implements OnInit, OnDestroy {
   // overlays
   showConfig = false;
   showHistory = false;
+  showScanner = false;
   histTab: 'live'|'db' = 'live';
 
   // UI
@@ -150,7 +152,8 @@ export class AppComponent implements OnInit, OnDestroy {
   // overlays
   openConfig() { this.showConfig = true; }
   openHistory() { this.showHistory = true; this.setHistTab('live'); }
-  closeOverlays() { this.showConfig = false; this.showHistory = false; }
+  openScanner() { this.showScanner = true; }
+  closeOverlays() { this.showConfig = false; this.showHistory = false; this.showScanner = false; }
 
   setHistTab(tab: 'live'|'db') { this.histTab = tab; if (tab === 'db') this.loadDbHistory(); }
 

--- a/frontend/src/app/components/scanner/scanner.component.css
+++ b/frontend/src/app/components/scanner/scanner.component.css
@@ -1,0 +1,10 @@
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.err {
+  color: #f44336;
+  margin-top: 8px;
+}

--- a/frontend/src/app/components/scanner/scanner.component.html
+++ b/frontend/src/app/components/scanner/scanner.component.html
@@ -1,0 +1,32 @@
+<div class="group">
+  <div class="group-title">Scanner Settings</div>
+  <div class="form-grid">
+    <label>Quote <input matInput [(ngModel)]="cfg.quote"></label>
+    <label>Min price <input matInput type="number" [(ngModel)]="cfg.min_price"></label>
+    <label>Min vol USDT 24h <input matInput type="number" [(ngModel)]="cfg.min_vol_usdt_24h"></label>
+    <label>Top by volume <input matInput type="number" [(ngModel)]="cfg.top_by_volume"></label>
+    <label>Max pairs <input matInput type="number" [(ngModel)]="cfg.max_pairs"></label>
+    <label>Min spread bps <input matInput type="number" [(ngModel)]="cfg.min_spread_bps"></label>
+  </div>
+  <button mat-stroked-button (click)="scan()" [disabled]="loading">{{ loading ? 'Scanning…' : 'Scan' }}</button>
+</div>
+<div *ngIf="err" class="err">{{ err }}</div>
+
+<div *ngIf="best" class="group">
+  <div class="group-title">Best: {{ best.symbol }}</div>
+  <div class="muted">Spread {{ best.spread_bps | number:'1.2-2' }} bps; Vol {{ best.vol_usdt_24h | number:'1.0-0' }}</div>
+</div>
+
+<table class="tbl small" *ngIf="top.length">
+  <thead>
+  <tr><th>Symbol</th><th>Spread bps</th><th>Vol USDT</th><th>Score</th></tr>
+  </thead>
+  <tbody>
+  <tr *ngFor="let s of top">
+    <td class="mono">{{ s.symbol }}</td>
+    <td class="mono">{{ s.spread_bps | number:'1.2-2' }}</td>
+    <td class="mono">{{ s.vol_usdt_24h | number:'1.0-0' }}</td>
+    <td class="mono">{{ s.score | number:'1.2-2' }}</td>
+  </tr>
+  </tbody>
+</table>

--- a/frontend/src/app/components/scanner/scanner.component.ts
+++ b/frontend/src/app/components/scanner/scanner.component.ts
@@ -1,0 +1,60 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { AppMaterialModule } from '../../app.module';
+import { ApiService } from '../../services/api.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Config, ConfigGetResponse, ConfigResponse, PairScore, ScanResponse } from '../../models';
+
+@Component({
+    selector: 'app-scanner',
+    standalone: true,
+    imports: [CommonModule, FormsModule, AppMaterialModule],
+    templateUrl: './scanner.component.html',
+    styleUrls: ['./scanner.component.css']
+})
+export class ScannerComponent {
+    cfg: any = {
+        quote: 'USDT',
+        min_price: 0.0001,
+        min_vol_usdt_24h: 3000000,
+        top_by_volume: 120,
+        max_pairs: 60,
+        min_spread_bps: 5.0,
+        vol_bars: 0,
+    };
+    loading = false;
+    err = '';
+    best?: PairScore;
+    top: PairScore[] = [];
+
+    constructor(private api: ApiService, private snack: MatSnackBar) {}
+
+    ngOnInit() {
+        const isCfgResp = (r: ConfigGetResponse): r is ConfigResponse => (r as ConfigResponse).cfg !== undefined;
+        this.api.getConfig().subscribe({
+            next: (res: ConfigGetResponse) => {
+                const cfg: Config = isCfgResp(res) ? res.cfg : res;
+                this.cfg = { ...this.cfg, ...(cfg.scanner || {}) };
+            },
+            error: _ => {}
+        });
+    }
+
+    scan() {
+        this.loading = true; this.err = '';
+        this.api.scan({ scanner: this.cfg }).subscribe({
+            next: (res: ScanResponse) => {
+                this.best = res.best;
+                this.top = Array.isArray(res.top) ? res.top : [];
+                this.loading = false;
+                this.snack.open('Scan complete', 'OK', { duration: 1200 });
+            },
+            error: (e: unknown) => {
+                const errObj = e as { error?: { detail?: string }; message?: string };
+                this.err = String(errObj.error?.detail || errObj.message || e);
+                this.loading = false;
+            }
+        });
+    }
+}

--- a/frontend/src/app/models.ts
+++ b/frontend/src/app/models.ts
@@ -45,6 +45,21 @@ export interface ConfigResponse {
 
 export type ConfigGetResponse = Config | ConfigResponse;
 
+export interface PairScore {
+  symbol: string;
+  bid: number;
+  ask: number;
+  spread_bps: number;
+  vol_usdt_24h: number;
+  vol_bps_1m: number;
+  score: number;
+}
+
+export interface ScanResponse {
+  best: PairScore;
+  top: PairScore[];
+}
+
 export interface HistoryStats {
   orders: number;
   trades: number;

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -13,6 +13,7 @@ import {
   OrderHistoryItem,
   RiskStatus,
   TradeHistoryItem,
+  ScanResponse,
 } from '../models';
 
 /** Статус бота: расширен под dashboard (metrics?, cfg?) */
@@ -48,7 +49,10 @@ export class ApiService {
   stop():   Observable<unknown>   { return this.http.post(`${this.api}/bot/stop`,  {}, this.auth()); }
 
   // ----------- SCANNER ---------
-  scan(): Observable<unknown>     { return this.http.post(`${this.api}/scanner/scan`, {}, this.auth()); }
+  scan(cfg?: Config): Observable<ScanResponse> {
+    const body = cfg ? { config: cfg } : {};
+    return this.http.post<ScanResponse>(`${this.api}/scanner/scan`, body, this.auth());
+  }
 
   // ----------- CONFIG ----------
   getConfig(): Observable<ConfigGetResponse> { return this.http.get<ConfigGetResponse>(`${this.api}/config`, this.auth()); }


### PR DESCRIPTION
## Summary
- auto-select trading pair on bot start via PairScanner when scanner enabled
- expose scanner API utilities and build scanner settings page with header entry
- log errors and selected symbol when scanning, with fallback to configured pair

## Testing
- `pytest`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Module "file:///workspace/Amadeus_0.1/frontend/.eslintrc.json" needs an import attribute of type "json")*

------
https://chatgpt.com/codex/tasks/task_e_68b78defc558832da023a74c1ec337ce