### PR TITLE
Align frontend tables and show final stats

### DIFF
--- a/frontend/src/app/components/controls/controls.component.ts
+++ b/frontend/src/app/components/controls/controls.component.ts
@@ -60,7 +60,13 @@ export class ControlsComponent implements OnDestroy {
       next: _ => {
         this.api.setRunning(false);
         this.running = false;
-        this.snack.open('Стоп', 'OK', { duration: 1200 });
+        // после остановки показываем финальную статистику
+        this.api.historyStats().subscribe(stats => {
+          this.api.historyTrades(10000, 0).subscribe(res => {
+            const pnl = (res.items || []).reduce((s, t) => s + (t.pnl || 0), 0);
+            this.snack.open(`Стоп. PnL: ${pnl.toFixed(2)}, Trades: ${stats.trades}`, 'OK', { duration: 4000 });
+          });
+        });
       },
       error: err => {
         this.snack.open(`Ошибка остановки: ${err?.error?.error || err?.message || 'unknown'}`, 'OK', { duration: 2500 });

--- a/frontend/src/app/components/history/history.component.css
+++ b/frontend/src/app/components/history/history.component.css
@@ -1,5 +1,16 @@
 .row { display:flex; gap:12px; align-items:center; flex-wrap: wrap; margin-bottom: 8px; }
 .two { display:grid; grid-template-columns: 1fr 1fr; gap: 12px; }
-table { width: 100%; border-collapse: collapse; }
-th, td { border-bottom: 1px solid #e0e0e0; padding: 6px; text-align: left; }
+table.tbl {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+.tbl th, .tbl td {
+  border-bottom: 1px solid #e0e0e0;
+  padding: 6px;
+  text-align: left;
+}
+.mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.pnl-positive { color:#2ecc71; font-weight:700; }
+.pnl-negative { color:#ff7675; font-weight:700; }
 @media (max-width: 1100px){ .two { grid-template-columns: 1fr; } }

--- a/frontend/src/app/components/history/history.component.html
+++ b/frontend/src/app/components/history/history.component.html
@@ -22,19 +22,27 @@
     <div>
         <h4>Orders (последние)</h4>
         <div *ngIf="loadingO">Загрузка...</div>
-        <table *ngIf="!loadingO">
+        <table *ngIf="!loadingO" class="tbl">
             <tr>
-                <th>ID</th><th>TS</th><th>Event</th><th>Symbol</th><th>Side</th><th>Type</th><th>Price</th><th>Qty</th><th>Status</th>
+                <th style="width:60px;">ID</th>
+                <th style="width:140px;">TS</th>
+                <th style="width:80px;">Event</th>
+                <th style="width:100px;">Symbol</th>
+                <th style="width:60px;">Side</th>
+                <th style="width:80px;">Type</th>
+                <th style="width:80px;">Price</th>
+                <th style="width:80px;">Qty</th>
+                <th style="width:80px;">Status</th>
             </tr>
             <tr *ngFor="let o of orders">
-                <td>{{o.id}}</td>
-                <td>{{o.ts*1000 | date:'medium'}}</td>
+                <td class="mono">{{o.id}}</td>
+                <td class="mono">{{o.ts*1000 | date:'medium'}}</td>
                 <td>{{o.event}}</td>
                 <td>{{o.symbol}}</td>
                 <td>{{o.side}}</td>
                 <td>{{o.type}}</td>
-                <td>{{o.price}}</td>
-                <td>{{o.qty}}</td>
+                <td class="mono">{{o.price}}</td>
+                <td class="mono">{{o.qty}}</td>
                 <td>{{o.status}}</td>
             </tr>
         </table>
@@ -43,19 +51,26 @@
     <div>
         <h4>Trades (последние)</h4>
         <div *ngIf="loadingT">Загрузка...</div>
-        <table *ngIf="!loadingT">
+        <table *ngIf="!loadingT" class="tbl">
             <tr>
-                <th>ID</th><th>TS</th><th>Type</th><th>Symbol</th><th>Side</th><th>Price</th><th>Qty</th><th>PNL</th>
+                <th style="width:60px;">ID</th>
+                <th style="width:140px;">TS</th>
+                <th style="width:80px;">Type</th>
+                <th style="width:100px;">Symbol</th>
+                <th style="width:60px;">Side</th>
+                <th style="width:80px;">Price</th>
+                <th style="width:80px;">Qty</th>
+                <th style="width:80px;">PNL</th>
             </tr>
             <tr *ngFor="let t of trades">
-                <td>{{t.id}}</td>
-                <td>{{t.ts*1000 | date:'medium'}}</td>
+                <td class="mono">{{t.id}}</td>
+                <td class="mono">{{t.ts*1000 | date:'medium'}}</td>
                 <td>{{t.type}}</td>
                 <td>{{t.symbol}}</td>
                 <td>{{t.side}}</td>
-                <td>{{t.price}}</td>
-                <td>{{t.qty}}</td>
-                <td>{{t.pnl}}</td>
+                <td class="mono">{{t.price}}</td>
+                <td class="mono">{{t.qty}}</td>
+                <td class="mono" [class.pnl-positive]="(t.pnl||0) > 0" [class.pnl-negative]="(t.pnl||0) < 0">{{t.pnl}}</td>
             </tr>
         </table>
     </div>

--- a/frontend/src/app/components/orders-widget/orders-widget.component.css
+++ b/frontend/src/app/components/orders-widget/orders-widget.component.css
@@ -1,6 +1,22 @@
 :host { display:block; }
-.tbl { width:100%; border-collapse:collapse; font-size: 12px; }
-.tbl th, .tbl td { border-bottom:1px solid #222; padding:4px 6px; text-align:left; }
+.tbl {
+  width:100%;
+  border-collapse:collapse;
+  font-size: 12px;
+  table-layout: fixed;
+}
+.tbl th, .tbl td {
+  border-bottom:1px solid #222;
+  padding:4px 6px;
+  text-align:left;
+}
+/* фиксированные ширины колонок */
+.tbl th:nth-child(1), .tbl td:nth-child(1) { width:60px; }
+.tbl th:nth-child(2), .tbl td:nth-child(2) { width:60px; }
+.tbl th:nth-child(3), .tbl td:nth-child(3) { width:100px; }
+.tbl th:nth-child(4), .tbl td:nth-child(4) { width:80px; }
+.tbl th:nth-child(5), .tbl td:nth-child(5) { width:80px; }
+.tbl th:nth-child(6), .tbl td:nth-child(6) { width:120px; }
 .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
 .buy { color:#2ecc71; font-weight:700; }
 .sell { color:#ff7675; font-weight:700; }

--- a/frontend/src/tradingview.html
+++ b/frontend/src/tradingview.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>TradingView Widget</title>
+  <style>
+    html,body,#tv_container{width:100%;height:100%;margin:0;padding:0;}
+  </style>
+</head>
+<body>
+  <div id="tv_container"></div>
+  <script type="text/javascript" src="https://s3.tradingview.com/tv.js"></script>
+  <script>
+    const symbol = new URLSearchParams(location.search).get('symbol') || 'AAPL';
+    new TradingView.widget({
+      symbol: symbol,
+      interval: 'D',
+      autosize: true,
+      container_id: 'tv_container',
+      timezone: 'Etc/UTC',
+      theme: 'dark'
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add table-layout styles and column widths for consistent alignment
- color trades PnL and compute final stats on bot stop
- include standalone TradingView HTML widget with dynamic symbol

## Testing
- `npm run lint` *(fails: Module needs an import attribute of type "json")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b795b69fd0832da1893811805a1cc5