### PR TITLE
feat: add runtime command toggles

### DIFF
--- a/backend/app/api/routers/bot.py
+++ b/backend/app/api/routers/bot.py
@@ -18,3 +18,9 @@ async def stop_bot(state = Depends(state_dep)):
 @router.get("/status", response_model=BotStatus)
 async def get_status(state = Depends(state_dep)):
     return state.status()
+
+
+@router.post("/cmd/{cmd}", response_model=BotStatus)
+async def handle_cmd(cmd: str, save: bool = False, state = Depends(state_dep)):
+    await state.handle_cmd(cmd, save=save)
+    return state.status()

--- a/frontend/src/app/models.ts
+++ b/frontend/src/app/models.ts
@@ -33,6 +33,10 @@ export interface Config {
   };
   strategy?: {
     symbol?: string;
+    market_maker?: {
+      aggressive_take?: boolean;
+      [key: string]: unknown;
+    };
     [key: string]: unknown;
   };
   [key: string]: unknown;

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -47,6 +47,10 @@ export class ApiService {
   status(): Observable<BotStatus> { return this.http.get<BotStatus>(`${this.api}/bot/status`, this.auth()); }
   start():  Observable<unknown>   { return this.http.post(`${this.api}/bot/start`, {}, this.auth()); }
   stop():   Observable<unknown>   { return this.http.post(`${this.api}/bot/stop`,  {}, this.auth()); }
+  cmd(command: string, save = false): Observable<BotStatus> {
+    const q = save ? '?save=1' : '';
+    return this.http.post<BotStatus>(`${this.api}/bot/cmd/${command}${q}`, {}, this.auth());
+  }
 
   // ----------- SCANNER ---------
   scan(cfg?: Config): Observable<ScanResponse> {


### PR DESCRIPTION
## Summary
- allow toggling paper mode, aggressive take, and quoting at runtime
- expose `/bot/cmd/{cmd}` endpoint and frontend hotkeys `p`, `a`, `s`

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ERR_IMPORT_ASSERTION_TYPE_MISSING)*

------
https://chatgpt.com/codex/tasks/task_e_68b798d11444832dad818461bf021ea9