### PR TITLE
Add capital usage control and funds display

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -78,6 +78,7 @@ class StrategyEconConfig(BaseModel):
 class MarketMakerStrategyConfig(BaseModel):
     symbol: str = "BNBUSDT"
     quote_size: float = 10.0
+    capital_usage: float = Field(1.0, ge=0.0, le=1.0)
     min_spread_pct: float = 0.0
     cancel_timeout: float = 10.0
     reorder_interval: float = 1.0

--- a/backend/app/services/state.py
+++ b/backend/app/services/state.py
@@ -653,6 +653,8 @@ class AppState:
                 "orders_filled",
                 "orders_expired",
                 "inventory_ratio",
+                "funds_in_use",
+                "funds_reserve",
             ):
                 val = getattr(self.strategy, key, None)
                 if val is not None:

--- a/backend/config.example.yaml
+++ b/backend/config.example.yaml
@@ -42,6 +42,7 @@ strategy:
   market_maker:
     symbol: BNBUSDT
     quote_size: 10.0
+    capital_usage: 1.0
     min_spread_pct: 0.0
     cancel_timeout: 10.0
     reorder_interval: 1.0

--- a/backend/data/runtime_config.json
+++ b/backend/data/runtime_config.json
@@ -15,6 +15,7 @@
   "strategy": {
     "symbol": "DYMUSDT",
     "quote_size": 10.0,
+    "capital_usage": 1.0,
     "min_spread_pct": 0.0,
     "cancel_timeout": 10.0,
     "post_only": true,

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -19,6 +19,8 @@
         <div class="muted">orders_active: {{ metrics?.orders_active || 0 }}</div>
         <div class="muted">orders_filled: {{ metrics?.orders_filled || 0 }}</div>
         <div class="muted">ticks_total: {{ metrics?.ticks_total || 0 }}</div>
+        <div class="muted">funds_in_use: {{ (metrics?.funds_in_use || 0) | number:'1.2-2' }}</div>
+        <div class="muted">funds_reserve: {{ (metrics?.funds_reserve || 0) | number:'1.2-2' }}</div>
     </div>
 </div>
 

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -76,6 +76,12 @@ export class DashboardComponent implements OnDestroy {
               ts,
               raw: m
             };
+          } else if (t === 'status') {
+            const s = msg as any;
+            this.running = !!s.running || this.running;
+            this.symbol = s.symbol || this.symbol;
+            if (s.metrics) this.metrics = { ...this.metrics, ...s.metrics };
+            if (s.cfg) this.cfg = { ...this.cfg, ...s.cfg };
           } else if (t === 'order_event' || t === 'trade' || t === 'fill') {
             const k = t + '_count';
             this.metrics[k] = (this.metrics[k] || 0) + 1;

--- a/frontend/src/app/models.ts
+++ b/frontend/src/app/models.ts
@@ -35,6 +35,7 @@ export interface Config {
     symbol?: string;
     market_maker?: {
       aggressive_take?: boolean;
+      capital_usage?: number;
       [key: string]: unknown;
     };
     [key: string]: unknown;

--- a/tests/test_market_maker_aggressive.py
+++ b/tests/test_market_maker_aggressive.py
@@ -23,6 +23,8 @@ def test_aggressive_take_places_taker_orders():
         }
     }
     mm = MarketMakerStrategy(cfg, DummyClient(), lambda evt: events.append(evt))
+    mm.cash = 1000.0
+    mm.position = 1.0
     mm.best_bid = 100.0
     mm.best_ask = 100.05
     asyncio.run(mm._step_once())
@@ -54,6 +56,8 @@ def test_aggressive_take_runtime_toggle():
         }
     }
     mm = MarketMakerStrategy(cfg, DummyClient(), lambda evt: events.append(evt))
+    mm.cash = 1000.0
+    mm.position = 1.0
     mm.best_bid = 100.0
     mm.best_ask = 100.05
     asyncio.run(mm._step_once())

--- a/tests/test_market_maker_capital_usage.py
+++ b/tests/test_market_maker_capital_usage.py
@@ -1,0 +1,36 @@
+import asyncio
+import pytest
+from backend.app.services.market_maker_strategy import MarketMakerStrategy
+
+
+class DummyClient:
+    pass
+
+
+def test_capital_usage_limits_order_size():
+    events = []
+    cfg = {
+        "strategy": {
+            "name": "market_maker",
+            "market_maker": {
+                "symbol": "TESTUSDT",
+                "quote_size": 10.0,
+                "capital_usage": 0.5,
+                "reorder_interval": 0.0,
+            },
+        }
+    }
+    mm = MarketMakerStrategy(cfg, DummyClient(), lambda evt: events.append(evt))
+    mm.cash = 10.0
+    mm.position = 1.0
+    mm.best_bid = 10.0
+    mm.best_ask = 10.2
+    asyncio.run(mm._step_once())
+    buy = next(o for o in mm.orders.values() if o.side == "BUY")
+    sell = next(o for o in mm.orders.values() if o.side == "SELL")
+    assert buy.qty * buy.price <= mm.cash * mm.capital_usage + 1e-9
+    assert sell.qty <= mm.position * mm.capital_usage + 1e-9
+    total_funds = 1.0 * 10.1 + 10.0
+    used = buy.qty * buy.price + sell.qty * sell.price
+    assert mm.funds_in_use == pytest.approx(used)
+    assert mm.funds_reserve == pytest.approx(total_funds - used)


### PR DESCRIPTION
## Summary
- allow configuration of `capital_usage` to cap strategy order size
- track and broadcast used vs. reserve funds, and show them on the dashboard
- test capital usage order sizing

## Testing
- `pytest`
- `npm run lint` *(fails: Module needs import attribute of type json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a0484d08832dbbfcd386b9dcc2ae