### PR TITLE
chore: add API token to config and frontend

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -130,7 +130,7 @@ class AppSettings(BaseSettings):
     app_reload: bool = Field(False, alias="APP_RELOAD")
     app_origins: str = Field("*", alias="APP_ORIGINS")
 
-    api_token: str = Field("secret-token", alias="API_TOKEN")
+    api_token: str = Field("b1a7528e92de0ce1e456b7afad435b47ce870dcb41688de2af9e815a5a65372c", alias="API_TOKEN")
 
     binance_api_key: Optional[str] = Field(None, alias="BINANCE_API_KEY")
     binance_api_secret: Optional[str] = Field(None, alias="BINANCE_API_SECRET")

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -24,7 +24,7 @@ export class ApiService {
   private readonly win = window as unknown as { __API__?: string; __TOKEN__?: string };
   private readonly baseRoot: string = (this.win.__API__ || environment.apiBaseUrl || 'http://127.0.0.1:8100').replace(/\/$/, '');
   readonly api: string = this.baseRoot + '/api';
-  private readonly _token: string = this.win.__TOKEN__ || 'secret-token';
+  private readonly _token: string = this.win.__TOKEN__ || 'b1a7528e92de0ce1e456b7afad435b47ce870dcb41688de2af9e815a5a65372c';
 
   private auth() { return { headers: { 'Authorization': `Bearer ${this._token}` } }; }
   get token(): string { return this._token; }

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -10,6 +10,7 @@
     <script>
         // жёстко указываем WS на 127.0.0.1:8100
         window.__WS__  = 'ws://127.0.0.1:8100/ws';
+        window.__TOKEN__ = 'b1a7528e92de0ce1e456b7afad435b47ce870dcb41688de2af9e815a5a65372c';
     </script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- generate static API token and embed it into backend config
- expose the same token to frontend through ApiService and index.html

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7a3a93c40832d92e2f896c7df76b0