### PR TITLE
Defer YAML config load to startup

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -191,4 +191,3 @@ class AppSettings(BaseSettings):
 
 
 settings = AppSettings()
-settings.load_yaml()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -59,18 +59,22 @@ app.include_router(ws_router.router)  # путь /ws
 # ---- Старт/стоп хуки ----
 @app.on_event("startup")
 async def on_startup():
-    """
-    Никакого state.load_config(): конфиг уже прочитан в core.config при импорте.
-    Здесь только синхронизируем cfg и НЕ автозапускаем бота,
-    если явно не указан api.autostart=true.
-    """
+    """Load runtime configuration and optionally start the bot."""
+    try:
+        settings.load_yaml()
+    except Exception as e:
+        log.exception("Failed to load configuration: %s", e)
+        raise
+
     state = get_state()
     state.cfg = settings.runtime_cfg or {}
-    log.info("Config синхронизирован: ui.chart=%s, api.paper=%s, api.shadow=%s, api.autostart=%s",
-             state.cfg.get("ui", {}).get("chart"),
-             state.cfg.get("api", {}).get("paper"),
-             state.cfg.get("api", {}).get("shadow"),
-             state.cfg.get("api", {}).get("autostart"))
+    log.info(
+        "Config синхронизирован: ui.chart=%s, api.paper=%s, api.shadow=%s, api.autostart=%s",
+        state.cfg.get("ui", {}).get("chart"),
+        state.cfg.get("api", {}).get("paper"),
+        state.cfg.get("api", {}).get("shadow"),
+        state.cfg.get("api", {}).get("autostart"),
+    )
 
     # НЕ автозапуск по умолчанию
     autostart = bool(state.cfg.get("api", {}).get("autostart", False))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,9 +13,11 @@ os.environ.setdefault("API_TOKEN", "test-token")
 
 from backend.app.main import app
 
+
 @pytest.fixture
 def client():
-    return TestClient(app)
+    with TestClient(app) as c:
+        yield c
 
 @pytest.fixture
 def auth_headers():

--- a/tests/test_startup_config_loading.py
+++ b/tests/test_startup_config_loading.py
@@ -1,0 +1,28 @@
+import os
+from fastapi.testclient import TestClient
+
+from backend.app.main import app
+from backend.app.core.config import settings
+from backend.app.services.state import get_state
+
+
+def test_load_yaml_on_startup(tmp_path):
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text("api:\n  paper: false\n")
+    os.environ["APP_CONFIG_FILE"] = str(cfg_path)
+
+    # Before startup, defaults should be in place
+    assert settings.runtime_cfg["api"]["paper"] is True
+
+    with TestClient(app):
+        pass  # triggers startup and shutdown
+
+    # After startup, config from file should be loaded
+    assert settings.runtime_cfg["api"]["paper"] is False
+    state = get_state()
+    assert state.cfg["api"]["paper"] is False
+
+    # Cleanup
+    os.environ.pop("APP_CONFIG_FILE", None)
+    settings.runtime_cfg = settings.default_cfg.copy()
+    state.cfg = settings.runtime_cfg


### PR DESCRIPTION
## Summary
- load runtime configuration during FastAPI startup instead of at import time
- run TestClient with lifespan to exercise startup hooks
- add test covering deferred config loading

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7a8b223b8832d82ea785bf4f8504f