### PR TITLE
Handle legacy inventory fields in config

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -166,10 +166,20 @@ class AppSettings(BaseSettings):
                     "symbol" in strat_section or "quote_size" in strat_section
                 ) and "market_maker" not in strat_section:
                     name = strat_section.pop("name", "market_maker")
-                    data["strategy"] = {
+                    strat_section = {
                         "name": name,
                         "market_maker": strat_section,
                     }
+                    data["strategy"] = strat_section
+
+                mm_cfg = strat_section.get("market_maker")
+                if isinstance(mm_cfg, dict):
+                    if "target_pct" in mm_cfg:
+                        mm_cfg.setdefault("inventory_target", mm_cfg.pop("target_pct"))
+                    if "target_range" in mm_cfg:
+                        mm_cfg.setdefault(
+                            "inventory_tolerance", mm_cfg.pop("target_range")
+                        )
 
             try:
                 cfg = RuntimeConfig.model_validate(data)

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -123,6 +123,30 @@ def test_defaults_when_sections_missing(tmp_path):
     assert s.runtime_cfg["strategy"]["market_maker"]["post_only"] is True
 
 
+def test_legacy_inventory_fields(tmp_path):
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text(
+        yaml.safe_dump(
+            {
+                "strategy": {
+                    "market_maker": {
+                        "target_pct": 0.25,
+                        "target_range": 0.1,
+                    }
+                }
+            }
+        )
+    )
+
+    s = AppSettings(app_config_file=str(cfg_file))
+    s.load_yaml()
+
+    mm = s.runtime_cfg["strategy"]["market_maker"]
+    assert mm["inventory_target"] == 0.25
+    assert mm["inventory_tolerance"] == 0.1
+    assert "target_pct" not in mm and "target_range" not in mm
+
+
 def test_dump_and_load_round_trip(tmp_path):
     cfg_data = {
         "api": {"paper": False, "autostart": True, "shadow": True},


### PR DESCRIPTION
## Summary
- map `target_pct` and `target_range` to `inventory_target` and `inventory_tolerance` when loading YAML
- ensure configs using legacy inventory fields still validate via new unit test

## Testing
- `pytest tests/test_config_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7aa9e0198832d9700f35a1c9fa0af