### PR TITLE
refactor: flatten order events

### DIFF
--- a/frontend/src/app/components/orders-widget/orders-widget.component.ts
+++ b/frontend/src/app/components/orders-widget/orders-widget.component.ts
@@ -31,13 +31,14 @@ export class OrdersWidgetComponent {
         this.ws.messages$.subscribe((msg: any) => {
             if (!msg || typeof msg !== 'object') return;
             if (msg.type === 'order_event') {
+                const o = msg.order || {};
                 const row: LiveOrder = {
-                    id: String(msg.id || ''),
-                    side: String(msg.side || 'BUY').toUpperCase() as any,
-                    price: Number(msg.price || 0),
-                    qty: Number(msg.qty || 0),
-                    status: String(msg.evt || msg.status || 'NEW').toUpperCase(),
-                    ts: Number(msg.ts || Date.now())
+                    id: String(msg.id || o.orderId || ''),
+                    side: String(msg.side || o.side || 'BUY').toUpperCase() as any,
+                    price: Number(msg.price || o.price || 0),
+                    qty: Number(msg.qty || o.qty || o.origQty || o.quantity || 0),
+                    status: String(msg.evt || msg.status || msg.event || o.status || 'NEW').toUpperCase(),
+                    ts: Number(msg.ts || msg.time || msg.T || o.updateTime || o.transactTime || Date.now())
                 };
                 // кладём сверху
                 this.orders.unshift(row);

--- a/tests/test_shadow_order_execution.py
+++ b/tests/test_shadow_order_execution.py
@@ -9,5 +9,5 @@ def test_partial_fill_emits_event():
     asyncio.run(client.shadow_exec.on_trade("TESTUSDT", price=100.0, qty=1.0, is_buyer_maker=False))
     updated = asyncio.run(client.get_order(symbol="TESTUSDT", orderId=order["orderId"]))
     assert updated["status"] == "PARTIALLY_FILLED"
-    assert any(e.get("event") == "PARTIALLY_FILLED" for e in events if e.get("type") == "order_event")
+    assert any(e.get("evt") == "PARTIALLY_FILLED" for e in events if e.get("type") == "order_event")
     asyncio.run(client.close())


### PR DESCRIPTION
## Summary
- emit flat order events from Binance client
- handle both flat and nested order events in history log
- parse legacy order_event format in orders widget
- align tests with new order event payload

## Testing
- `pytest -q`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7b3a13bdc832daa9cb9d8b8b5f3ba