### PR TITLE
Enable standalone scanner with temporary Binance client

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,29 @@ All API and WebSocket endpoints require a static bearer token.
 
 Changing `API_TOKEN` will invalidate existing clients.
 
+## Standalone scanner
+
+The pair scanner can be used without starting the trading bot. The `/scanner/scan` route will
+create a temporary Binance `AsyncClient` when no global client is available. Provide your API
+credentials via environment variables before launching the backend:
+
+```bash
+export BINANCE_API_KEY="your_key"
+export BINANCE_API_SECRET="your_secret"
+uvicorn app.main:app --host 0.0.0.0 --port 8000
+```
+
+Then call the scanner endpoint:
+
+```bash
+curl -X POST "http://localhost:8000/scanner/scan" \
+     -H "Authorization: Bearer $API_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{}'
+```
+
+The request returns the best trading pair and the top candidates based on your configuration.
+
 ## Testing
 
 1. Install dependencies:

--- a/backend/app/api/routers/scanner.py
+++ b/backend/app/api/routers/scanner.py
@@ -1,15 +1,41 @@
 from __future__ import annotations
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
+from binance import AsyncClient
+
 from ...deps import state_dep
 from ...models.schemas import ScanRequest, ScanResponse
 from ...services.pair_scanner import scan_best_symbol
+from ...core.config import settings
 
 router = APIRouter(prefix="/scanner", tags=["scanner"])
 
+
 @router.post("/scan", response_model=ScanResponse)
 async def scan(req: ScanRequest, state = Depends(state_dep)):
-    if not state.binance or not state.binance.client:
-        raise HTTPException(status_code=400, detail="Binance client not initialized. Start the bot first.")
     cfg = req.config or state.cfg
-    data = await scan_best_symbol(cfg, state.binance.client)
+
+    client: AsyncClient
+    close_client = False
+
+    if state.binance and getattr(state.binance, "client", None):
+        client = state.binance.client
+    else:
+        api_cfg = cfg.get("api", {}) if isinstance(cfg, dict) else {}
+        paper = bool(api_cfg.get("paper", True))
+        client = await AsyncClient.create(
+            settings.binance_api_key,
+            settings.binance_api_secret,
+            testnet=paper,
+        )
+        close_client = True
+
+    try:
+        data = await scan_best_symbol(cfg, client)
+    finally:
+        if close_client:
+            try:
+                await client.close_connection()
+            except Exception:
+                pass
+
     return ScanResponse(best=data["best"], top=data["top"])


### PR DESCRIPTION
## Summary
- Instantiate temporary Binance AsyncClient in scanner when global client missing
- Ensure temporary clients are closed after scanning
- Document standalone scanner usage and environment variables for API keys

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7b4964298832da7cc24ec523ea694