### PR TITLE
Remove logs toolbar and cleanup styles

### DIFF
--- a/frontend/src/app/components/logs/logs.component.css
+++ b/frontend/src/app/components/logs/logs.component.css
@@ -1,11 +1,6 @@
 /* контейнер занимает высоту карточки и не растягивает родителя */
 .logs { display:flex; flex-direction:column; height:100%; gap:8px; min-height:0; }
 
-/* шапка блока */
-.bar { display:flex; align-items:center; gap:8px; }
-.title { font-weight:700; }
-.spacer { flex:1 1 auto; }
-
 /* область со скроллом
    ВАЖНО: min-height:0 — чтобы flex-элемент позволял внутреннему скроллу,
    а не растягивал колонку */

--- a/frontend/src/app/components/logs/logs.component.html
+++ b/frontend/src/app/components/logs/logs.component.html
@@ -1,12 +1,4 @@
 <div class="logs">
-    <div class="bar">
-        <div class="title">Логи</div>
-        <span class="spacer"></span>
-        <button mat-icon-button (click)="clear()" matTooltip="Очистить">
-            <mat-icon>delete_sweep</mat-icon>
-        </button>
-    </div>
-
     <div class="pane" #pane>
         <table class="tbl">
             <thead>


### PR DESCRIPTION
## Summary
- remove toolbar block from logs component HTML
- drop unused .bar/.title/.spacer CSS rules

## Testing
- `npm test` *(missing script: "test")*
- `npm run lint` *(TypeError [ERR_IMPORT_ASSERTION_TYPE_MISSING])*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7bb7db964832dad27e05dd1cf799e