### PR TITLE
Display newest logs at top and trim correctly

### DIFF
--- a/frontend/src/app/components/logs/logs.component.ts
+++ b/frontend/src/app/components/logs/logs.component.ts
@@ -61,8 +61,10 @@ export class LogsComponent {
                 text = text || JSON.stringify(evt);
         }
 
-        this.rows.push({ ts: t, type, text });
-        if (this.rows.length > this.maxRows) this.rows.splice(0, this.rows.length - this.maxRows);
+        // Add newest entries to the beginning so they're shown at the top
+        this.rows.unshift({ ts: t, type, text });
+        // Trim array when exceeding maxRows by removing items from the end
+        if (this.rows.length > this.maxRows) this.rows.splice(this.maxRows);
     }
 
     clear() { this.rows = []; }


### PR DESCRIPTION
## Summary
- Prepend incoming log entries so new messages appear at the top
- Trim log list from the end when exceeding max rows

## Testing
- `npm run lint` *(fails: TypeError [ERR_IMPORT_ASSERTION_TYPE_MISSING])* 
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7bb8d6728832db2c80c9d2c7f3d37