### PR TITLE
Gracefully handle missing pairs in scanner endpoint

### DIFF
--- a/backend/app/api/routers/scanner.py
+++ b/backend/app/api/routers/scanner.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from binance import AsyncClient
 
 from ...deps import state_dep
@@ -31,6 +31,8 @@ async def scan(req: ScanRequest, state = Depends(state_dep)):
 
     try:
         data = await scan_best_symbol(cfg, client)
+    except RuntimeError:
+        raise HTTPException(status_code=404, detail="no pairs found")
     finally:
         if close_client:
             try:


### PR DESCRIPTION
## Summary
- handle `RuntimeError` from `scan_best_symbol`
- return 404 with descriptive payload when no pairs found

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7be09a060832d88af0a9929dd1b9d