### PR TITLE
Lower scanner thresholds for testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ curl -X POST "http://localhost:8000/scanner/scan" \
 
 The request returns the best trading pair and the top candidates based on your configuration.
 
+The scanner's `min_vol_usdt_24h` and `min_spread_bps` thresholds are tuned for
+liquid mainnet markets. When using Binance testnet (`api.paper: true`) or
+trading pairs with low liquidity, lower these values; otherwise the scanner may
+reject all candidates. The backend automatically falls back to near-zero
+thresholds in paper mode, but adjust them as needed for your environment.
+
 ## Testing
 
 1. Install dependencies:

--- a/backend/app/services/pair_scanner.py
+++ b/backend/app/services/pair_scanner.py
@@ -77,12 +77,13 @@ async def _gather_limited(coros, limit: int = 20):
 
 async def _scan_impl(cfg: Dict[str, Any], client: BinanceClientProtocol) -> Dict[str, Any]:
     sc = cfg.get("scanner", {})
+    paper = bool(cfg.get("api", {}).get("paper", False))
     quote = sc.get("quote", "USDT")
     min_price = float(sc.get("min_price", 0.0001))
-    min_vol_usdt = float(sc.get("min_vol_usdt_24h", 3_000_000))
+    min_vol_usdt = float(sc.get("min_vol_usdt_24h", 0 if paper else 3_000_000))
     top_by_volume = int(sc.get("top_by_volume", 120))
     max_pairs = int(sc.get("max_pairs", 60))
-    min_spread_bps = float(sc.get("min_spread_bps", 5.0))
+    min_spread_bps = float(sc.get("min_spread_bps", 0.0 if paper else 5.0))
     vol_bars = int(sc.get("vol_bars", 0))
     w_spread = float(sc.get("score", {}).get("w_spread", 1.0))
     w_vol = float(sc.get("score", {}).get("w_vol", 0.3))

--- a/backend/config.example.yaml
+++ b/backend/config.example.yaml
@@ -27,10 +27,10 @@ scanner:
   enabled: false
   quote: USDT
   min_price: 0.0001
-  min_vol_usdt_24h: 3000000
+  min_vol_usdt_24h: 0
   top_by_volume: 120
   max_pairs: 60
-  min_spread_bps: 5.0
+  min_spread_bps: 0.0
   vol_bars: 0
   score:
     w_spread: 1.0


### PR DESCRIPTION
## Summary
- Drop scanner volume and spread defaults to zero in paper/testnet mode
- Adjust pair scanner to use relaxed thresholds on testnet
- Document low-liquidity threshold tuning and update example config

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7be8ec330832d8404f426615dcc7f