### PR TITLE
test: add coverage for low spread pairs

### DIFF
--- a/tests/test_pair_scanner.py
+++ b/tests/test_pair_scanner.py
@@ -70,3 +70,78 @@ def test_scan_best_symbol_binance_rest_client():
         await client.aclose()
 
     asyncio.run(_run())
+
+
+def test_scan_best_symbol_no_pairs_due_to_spread():
+    async def _run():
+        exchange_info = {
+            "symbols": [
+                {"symbol": "BTCUSDT", "status": "TRADING", "quoteAsset": "USDT", "isSpotTradingAllowed": True},
+                {"symbol": "ETHUSDT", "status": "TRADING", "quoteAsset": "USDT", "isSpotTradingAllowed": True},
+            ]
+        }
+        tickers = {
+            "BTCUSDT": {"symbol": "BTCUSDT", "quoteVolume": "1000000", "lastPrice": "20000"},
+            "ETHUSDT": {"symbol": "ETHUSDT", "quoteVolume": "2000000", "lastPrice": "1500"},
+        }
+        books = {
+            # spreads are well below the 5 bps threshold
+            "BTCUSDT": {"symbol": "BTCUSDT", "bidPrice": "20000", "askPrice": "20000.5"},
+            "ETHUSDT": {"symbol": "ETHUSDT", "bidPrice": "1500", "askPrice": "1500.05"},
+        }
+        klines = {
+            "BTCUSDT": [
+                [0, 0, "20000.5", "19999.5", "20000", "0", 0, 0, 0, 0, 0, 0],
+                [0, 0, "20001", "19999", "20000", "0", 0, 0, 0, 0, 0, 0],
+            ],
+            "ETHUSDT": [
+                [0, 0, "1500.05", "1499.95", "1500", "0", 0, 0, 0, 0, 0, 0],
+                [0, 0, "1500.1", "1499.9", "1500", "0", 0, 0, 0, 0, 0, 0],
+            ],
+        }
+
+        def handler(request: Request) -> Response:
+            path = request.url.path
+            if path == "/api/v3/exchangeInfo":
+                return Response(200, json=exchange_info)
+            if path == "/api/v3/ticker/24hr":
+                sym = request.url.params["symbol"]
+                return Response(200, json=tickers[sym])
+            if path == "/api/v3/ticker/bookTicker":
+                sym = request.url.params["symbol"]
+                return Response(200, json=books[sym])
+            if path == "/api/v3/klines":
+                sym = request.url.params["symbol"]
+                return Response(200, json=klines[sym])
+            return Response(404)
+
+        transport = MockTransport(handler)
+        client = BinanceRestClient(api_key=None, api_secret=None, paper=True)
+        client._client = httpx.AsyncClient(transport=transport, base_url="https://test/api")
+
+        cfg = {
+            "scanner": {
+                "quote": "USDT",
+                "min_price": 0,
+                "min_vol_usdt_24h": 0,
+                "top_by_volume": 10,
+                "max_pairs": 10,
+                "min_spread_bps": 5,
+                "vol_bars": 2,
+                "score": {"w_spread": 1.0, "w_vol": 0.0},
+            }
+        }
+
+        try:
+            result = await scan_best_symbol(cfg, client)
+        except RuntimeError as e:
+            assert "spread" in str(e)
+        else:
+            assert isinstance(result, dict)
+            assert not result.get("top")
+            msg = (result.get("message") or "").lower()
+            assert "spread" in msg
+        finally:
+            await client.aclose()
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add regression test to ensure `scan_best_symbol` handles low-spread candidates gracefully

## Testing
- `pytest tests/test_pair_scanner.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7bea85890832da8543794210363f6