### PR TITLE
Add Material icon fonts and candlestick chart set

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -47,7 +47,8 @@
                     <!-- Переключатель графика в правом углу шапки карточки -->
                     <button mat-icon-button aria-label="Chart mode" (click)="toggleChart()"
                             [matTooltip]="isTv() ? 'Переключить на Lightweight' : 'Переключить на TradingView'">
-                        <mat-icon>{{ isTv() ? 'candlestick_chart' : 'show_chart' }}</mat-icon>
+                        <mat-icon *ngIf="isTv()" fontSet="material-symbols-outlined">candlestick_chart</mat-icon>
+                        <mat-icon *ngIf="!isTv()">show_chart</mat-icon>
                     </button>
                 </div>
             </div>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -7,6 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/x-icon" href="favicon.ico">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
     <script>
         // жёстко указываем WS на 127.0.0.1:8100
         window.__WS__  = 'ws://127.0.0.1:8100/ws';


### PR DESCRIPTION
## Summary
- include Material Icons and Material Symbols font links in index
- use `material-symbols-outlined` font set for `candlestick_chart` icon

## Testing
- `npm run lint` *(fails: Module needs an import attribute of type 'json')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7c2bc7a1c832db52b0c3d0caefb7a