### PR TITLE
feat(frontend): add reactive config form

### DIFF
--- a/frontend/src/app/components/config/config.component.html
+++ b/frontend/src/app/components/config/config.component.html
@@ -1,14 +1,102 @@
 <div>
-    <div class="row">
-        <button mat-stroked-button color="primary" (click)="load()">Обновить</button>
-        <button mat-stroked-button color="accent" (click)="save()">Сохранить</button>
-        <button mat-stroked-button (click)="loadDefault()">Дефолт</button>
-        <button mat-stroked-button (click)="restoreBackup()">Откат</button>
-        <button mat-stroked-button (click)="clearLocal()">Очистить localStorage</button>
+  <div class="row">
+    <button mat-stroked-button color="primary" (click)="load()">Обновить</button>
+    <button mat-stroked-button color="accent" (click)="save()">Сохранить</button>
+    <button mat-stroked-button (click)="loadDefault()">Дефолт</button>
+    <button mat-stroked-button (click)="restoreBackup()">Откат</button>
+    <button mat-stroked-button (click)="clearLocal()">Очистить localStorage</button>
+  </div>
+
+  <div *ngIf="loading" class="muted" style="margin-top:8px">Загрузка…</div>
+  <div *ngIf="err" class="err" style="margin-top:8px">{{ err }}</div>
+
+  <form [formGroup]="cfgForm">
+    <div formGroupName="api">
+      <mat-card>
+        <mat-card-title>API</mat-card-title>
+        <mat-card-content>
+          <mat-slide-toggle formControlName="paper">Paper</mat-slide-toggle>
+          <mat-slide-toggle formControlName="shadow">Shadow</mat-slide-toggle>
+          <mat-slide-toggle formControlName="autostart">Autostart</mat-slide-toggle>
+        </mat-card-content>
+      </mat-card>
     </div>
 
-    <div *ngIf="loading" class="muted" style="margin-top:8px">Загрузка…</div>
-    <div *ngIf="err" class="err" style="margin-top:8px">{{ err }}</div>
+    <div formGroupName="shadow">
+      <mat-card>
+        <mat-card-title>Shadow</mat-card-title>
+        <mat-card-content>
+          <mat-form-field>
+            <mat-label>REST base</mat-label>
+            <input matInput formControlName="rest_base" />
+          </mat-form-field>
+          <mat-form-field>
+            <mat-label>WS base</mat-label>
+            <input matInput formControlName="ws_base" />
+          </mat-form-field>
+        </mat-card-content>
+      </mat-card>
+    </div>
 
-    <textarea class="cfg" [(ngModel)]="text" rows="26" spellcheck="false"></textarea>
+    <div formGroupName="ui">
+      <mat-card>
+        <mat-card-title>UI</mat-card-title>
+        <mat-card-content>
+          <mat-form-field>
+            <mat-label>Chart</mat-label>
+            <input matInput formControlName="chart" />
+          </mat-form-field>
+          <mat-radio-group formControlName="theme">
+            <mat-radio-button value="light">Light</mat-radio-button>
+            <mat-radio-button value="dark">Dark</mat-radio-button>
+          </mat-radio-group>
+        </mat-card-content>
+      </mat-card>
+    </div>
+
+    <div formGroupName="risk">
+      <mat-card>
+        <mat-card-title>Risk</mat-card-title>
+        <mat-card-content>
+          <mat-form-field>
+            <mat-label>Max drawdown %</mat-label>
+            <input matInput type="number" formControlName="max_drawdown_pct" />
+          </mat-form-field>
+          <mat-form-field>
+            <mat-label>DD window sec</mat-label>
+            <input matInput type="number" formControlName="dd_window_sec" />
+          </mat-form-field>
+          <mat-form-field>
+            <mat-label>Stop duration sec</mat-label>
+            <input matInput type="number" formControlName="stop_duration_sec" />
+          </mat-form-field>
+          <mat-form-field>
+            <mat-label>Cooldown sec</mat-label>
+            <input matInput type="number" formControlName="cooldown_sec" />
+          </mat-form-field>
+          <mat-form-field>
+            <mat-label>Min trades for DD</mat-label>
+            <input matInput type="number" formControlName="min_trades_for_dd" />
+          </mat-form-field>
+        </mat-card-content>
+      </mat-card>
+    </div>
+
+    <div formGroupName="strategy">
+      <mat-card>
+        <mat-card-title>Strategy</mat-card-title>
+        <mat-card-content>
+          <mat-form-field>
+            <mat-label>Symbol</mat-label>
+            <input matInput formControlName="symbol" />
+          </mat-form-field>
+          <div formGroupName="market_maker">
+            <mat-slide-toggle formControlName="aggressive_take">Aggressive take</mat-slide-toggle>
+            <mat-slider formControlName="capital_usage" min="0" max="1" step="0.1" thumbLabel></mat-slider>
+          </div>
+        </mat-card-content>
+      </mat-card>
+    </div>
+  </form>
 </div>
+

--- a/frontend/src/app/components/config/config.component.ts
+++ b/frontend/src/app/components/config/config.component.ts
@@ -3,83 +3,139 @@ import { CommonModule } from '@angular/common';
 import { AppMaterialModule } from '../../app.module';
 import { ApiService } from '../../services/api.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { FormsModule } from '@angular/forms'; // ⬅️ добавили
+import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { Config, ConfigGetResponse, ConfigResponse } from '../../models';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatSliderModule } from '@angular/material/slider';
+import { MatFormFieldModule } from '@angular/material/form-field';
 
 @Component({
-    selector: 'app-config',
-    standalone: true,
-    imports: [CommonModule, AppMaterialModule, FormsModule], // ⬅️ добавили FormsModule
-    templateUrl: './config.component.html',
-    styleUrls: ['./config.component.css']
+  selector: 'app-config',
+  standalone: true,
+  imports: [
+    CommonModule,
+    AppMaterialModule,
+    ReactiveFormsModule,
+    MatRadioModule,
+    MatSliderModule,
+    MatFormFieldModule,
+  ],
+  templateUrl: './config.component.html',
+  styleUrls: ['./config.component.css'],
 })
 export class ConfigComponent {
-    text = '{\n}\n';
-    loading = true;
-    err = '';
+  loading = true;
+  err = '';
+  cfgForm: FormGroup;
 
-    constructor(private api: ApiService, private snack: MatSnackBar) {}
+  constructor(
+    private api: ApiService,
+    private snack: MatSnackBar,
+    private fb: FormBuilder
+  ) {
+    this.cfgForm = this.fb.group({
+      api: this.fb.group({
+        paper: [false],
+        shadow: [false],
+        autostart: [false],
+      }),
+      shadow: this.fb.group({
+        rest_base: [''],
+        ws_base: [''],
+      }),
+      ui: this.fb.group({
+        chart: [''],
+        theme: [''],
+      }),
+      risk: this.fb.group({
+        max_drawdown_pct: [0],
+        dd_window_sec: [0],
+        stop_duration_sec: [0],
+        cooldown_sec: [0],
+        min_trades_for_dd: [0],
+      }),
+      strategy: this.fb.group({
+        symbol: [''],
+        market_maker: this.fb.group({
+          aggressive_take: [false],
+          capital_usage: [0],
+        }),
+      }),
+    });
+  }
 
-    ngOnInit() { this.load(); }
+  ngOnInit() {
+    this.load();
+  }
 
-    load() {
-        this.loading = true; this.err = '';
-        const isConfigResp = (r: ConfigGetResponse): r is ConfigResponse => (r as ConfigResponse).cfg !== undefined;
-        this.api.getConfig().subscribe({
-            next: (res: ConfigGetResponse) => {
-                const cfg: Config = isConfigResp(res) ? res.cfg : res;
-                this.text = JSON.stringify(cfg ?? {}, null, 2);
-                this.loading = false;
-            },
-            error: (e: unknown) => {
-                this.err = String((e as { message?: string })?.message || e);
-                this.loading = false;
-            }
-        });
-    }
+  load() {
+    this.loading = true;
+    this.err = '';
+    const isConfigResp = (
+      r: ConfigGetResponse
+    ): r is ConfigResponse => (r as ConfigResponse).cfg !== undefined;
+    this.api.getConfig().subscribe({
+      next: (res: ConfigGetResponse) => {
+        const cfg: Config = isConfigResp(res) ? res.cfg : res;
+        this.cfgForm.reset();
+        if (cfg) this.cfgForm.patchValue(cfg);
+        this.loading = false;
+      },
+      error: (e: unknown) => {
+        this.err = String((e as { message?: string })?.message || e);
+        this.loading = false;
+      },
+    });
+  }
 
-    save() {
-        this.err = '';
-        const raw = this.text?.trim();
-        if (!raw) { this.err = 'Нельзя сохранять пустой конфиг.'; return; }
-        let parsed: Config | string;
-        try {
-            parsed = JSON.parse(raw) as Config;
-        } catch {
-            // отправим как строку — бэкенд сам умеет YAML/JSON
-            parsed = raw;
-        }
-        this.api.putConfig(parsed).subscribe({
-            next: () => { this.snack.open('Сохранено', 'OK', { duration: 1200 }); this.load(); },
-            error: (e: unknown) => {
-                const errObj = e as { error?: { detail?: string }; message?: string };
-                this.err = String(errObj.error?.detail || errObj.message || e);
-            }
-        });
-    }
+  save() {
+    this.err = '';
+    const cfg = this.cfgForm.getRawValue() as Config;
+    this.api.putConfig(cfg).subscribe({
+      next: () => {
+        this.snack.open('Сохранено', 'OK', { duration: 1200 });
+        this.load();
+      },
+      error: (e: unknown) => {
+        const errObj = e as { error?: { detail?: string }; message?: string };
+        this.err = String(errObj.error?.detail || errObj.message || e);
+      },
+    });
+  }
 
-    loadDefault() {
-        this.api.getDefaultConfig().subscribe({
-            next: (res: ConfigResponse) => { this.text = JSON.stringify(res?.cfg ?? {}, null, 2); },
-            error: (e: unknown) => { this.err = String((e as { message?: string })?.message || e); }
-        });
-    }
+  loadDefault() {
+    this.api.getDefaultConfig().subscribe({
+      next: (res: ConfigResponse) => {
+        this.cfgForm.reset();
+        if (res?.cfg) this.cfgForm.patchValue(res.cfg);
+      },
+      error: (e: unknown) => {
+        this.err = String((e as { message?: string })?.message || e);
+      },
+    });
+  }
 
-    restoreBackup() {
-        this.api.restoreConfig().subscribe({
-            next: (res: ConfigResponse) => {
-                this.text = JSON.stringify(res?.cfg ?? {}, null, 2);
-                this.snack.open('Откат выполнен', 'OK', { duration: 1200 });
-            },
-            error: (e: unknown) => {
-                const errObj = e as { error?: { detail?: string }; message?: string };
-                this.err = String(errObj.error?.detail || errObj.message || e);
-            }
-        });
-    }
+  restoreBackup() {
+    this.api.restoreConfig().subscribe({
+      next: (res: ConfigResponse) => {
+        this.cfgForm.reset();
+        if (res?.cfg) this.cfgForm.patchValue(res.cfg);
+        this.snack.open('Откат выполнен', 'OK', { duration: 1200 });
+      },
+      error: (e: unknown) => {
+        const errObj = e as { error?: { detail?: string }; message?: string };
+        this.err = String(errObj.error?.detail || errObj.message || e);
+      },
+    });
+  }
 
-    clearLocal() {
-        try { localStorage.clear(); sessionStorage.clear(); } catch {}
-        this.snack.open('Кэш браузера очищен (local/session).', 'OK', { duration: 1200 });
-    }
+  clearLocal() {
+    try {
+      localStorage.clear();
+      sessionStorage.clear();
+    } catch {}
+    this.snack.open('Кэш браузера очищен (local/session).', 'OK', {
+      duration: 1200,
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- use reactive form to edit bot configuration and load/save via API
- replace raw textarea with material controls grouped by sections

## Testing
- `npm --prefix frontend run lint` *(fails: Module needs an import attribute of type "json")*
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7c7c12ba8832da2dbf564bf4d1c87