### PR TITLE
feat(frontend): add tooltips to config inputs

### DIFF
--- a/frontend/src/app/components/config/config.component.html
+++ b/frontend/src/app/components/config/config.component.html
@@ -15,9 +15,9 @@
       <mat-card>
         <mat-card-title>API</mat-card-title>
         <mat-card-content>
-          <mat-slide-toggle formControlName="paper">Paper</mat-slide-toggle>
-          <mat-slide-toggle formControlName="shadow">Shadow</mat-slide-toggle>
-          <mat-slide-toggle formControlName="autostart">Autostart</mat-slide-toggle>
+          <mat-slide-toggle formControlName="paper" [matTooltip]="tips.paper">Paper</mat-slide-toggle>
+          <mat-slide-toggle formControlName="shadow" [matTooltip]="tips.shadow">Shadow</mat-slide-toggle>
+          <mat-slide-toggle formControlName="autostart" [matTooltip]="tips.autostart">Autostart</mat-slide-toggle>
         </mat-card-content>
       </mat-card>
     </div>
@@ -28,11 +28,11 @@
         <mat-card-content>
           <mat-form-field>
             <mat-label>REST base</mat-label>
-            <input matInput formControlName="rest_base" />
+            <input matInput formControlName="rest_base" [matTooltip]="tips.rest_base" />
           </mat-form-field>
           <mat-form-field>
             <mat-label>WS base</mat-label>
-            <input matInput formControlName="ws_base" />
+            <input matInput formControlName="ws_base" [matTooltip]="tips.ws_base" />
           </mat-form-field>
         </mat-card-content>
       </mat-card>
@@ -44,11 +44,11 @@
         <mat-card-content>
           <mat-form-field>
             <mat-label>Chart</mat-label>
-            <input matInput formControlName="chart" />
+            <input matInput formControlName="chart" [matTooltip]="tips.chart" />
           </mat-form-field>
           <mat-radio-group formControlName="theme">
-            <mat-radio-button value="light">Light</mat-radio-button>
-            <mat-radio-button value="dark">Dark</mat-radio-button>
+            <mat-radio-button value="light" [matTooltip]="tips.theme_light">Light</mat-radio-button>
+            <mat-radio-button value="dark" [matTooltip]="tips.theme_dark">Dark</mat-radio-button>
           </mat-radio-group>
         </mat-card-content>
       </mat-card>
@@ -60,23 +60,23 @@
         <mat-card-content>
           <mat-form-field>
             <mat-label>Max drawdown %</mat-label>
-            <input matInput type="number" formControlName="max_drawdown_pct" />
+            <input matInput type="number" formControlName="max_drawdown_pct" [matTooltip]="tips.max_drawdown_pct" />
           </mat-form-field>
           <mat-form-field>
             <mat-label>DD window sec</mat-label>
-            <input matInput type="number" formControlName="dd_window_sec" />
+            <input matInput type="number" formControlName="dd_window_sec" [matTooltip]="tips.dd_window_sec" />
           </mat-form-field>
           <mat-form-field>
             <mat-label>Stop duration sec</mat-label>
-            <input matInput type="number" formControlName="stop_duration_sec" />
+            <input matInput type="number" formControlName="stop_duration_sec" [matTooltip]="tips.stop_duration_sec" />
           </mat-form-field>
           <mat-form-field>
             <mat-label>Cooldown sec</mat-label>
-            <input matInput type="number" formControlName="cooldown_sec" />
+            <input matInput type="number" formControlName="cooldown_sec" [matTooltip]="tips.cooldown_sec" />
           </mat-form-field>
           <mat-form-field>
             <mat-label>Min trades for DD</mat-label>
-            <input matInput type="number" formControlName="min_trades_for_dd" />
+            <input matInput type="number" formControlName="min_trades_for_dd" [matTooltip]="tips.min_trades_for_dd" />
           </mat-form-field>
         </mat-card-content>
       </mat-card>
@@ -88,11 +88,11 @@
         <mat-card-content>
           <mat-form-field>
             <mat-label>Symbol</mat-label>
-            <input matInput formControlName="symbol" />
+            <input matInput formControlName="symbol" [matTooltip]="tips.symbol" />
           </mat-form-field>
           <div formGroupName="market_maker">
-            <mat-slide-toggle formControlName="aggressive_take">Aggressive take</mat-slide-toggle>
-            <mat-slider formControlName="capital_usage" min="0" max="1" step="0.1" thumbLabel></mat-slider>
+            <mat-slide-toggle formControlName="aggressive_take" [matTooltip]="tips.aggressive_take">Aggressive take</mat-slide-toggle>
+            <mat-slider formControlName="capital_usage" min="0" max="1" step="0.1" thumbLabel [matTooltip]="tips.capital_usage"></mat-slider>
           </div>
         </mat-card-content>
       </mat-card>

--- a/frontend/src/app/components/config/config.component.ts
+++ b/frontend/src/app/components/config/config.component.ts
@@ -8,6 +8,7 @@ import { Config, ConfigGetResponse, ConfigResponse } from '../../models';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatSliderModule } from '@angular/material/slider';
 import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @Component({
   selector: 'app-config',
@@ -19,6 +20,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
     MatRadioModule,
     MatSliderModule,
     MatFormFieldModule,
+    MatTooltipModule,
   ],
   templateUrl: './config.component.html',
   styleUrls: ['./config.component.css'],
@@ -27,6 +29,24 @@ export class ConfigComponent {
   loading = true;
   err = '';
   cfgForm: FormGroup;
+  tips = {
+    paper: 'Режим бумажной торговли без реальных сделок',
+    shadow: 'Дублировать сделки в теневом API',
+    autostart: 'Запускать бота автоматически',
+    rest_base: 'Базовый REST URL теневого API',
+    ws_base: 'Базовый WebSocket URL теневого API',
+    chart: 'URL шаблона графика',
+    theme_light: 'Светлая тема интерфейса',
+    theme_dark: 'Тёмная тема интерфейса',
+    max_drawdown_pct: 'Максимальная допустимая просадка',
+    dd_window_sec: 'Окно расчёта просадки в секундах',
+    stop_duration_sec: 'Длительность остановки после просадки',
+    cooldown_sec: 'Пауза после остановки в секундах',
+    min_trades_for_dd: 'Минимум сделок для учёта просадки',
+    symbol: 'Торговый инструмент',
+    aggressive_take: 'Агрессивно забирать лучшие цены',
+    capital_usage: 'Доля капитала в сделке',
+  };
 
   constructor(
     private api: ApiService,


### PR DESCRIPTION
## Summary
- add tooltip dictionary for config form
- show descriptive matTooltips on all config inputs

## Testing
- `npm run lint` *(fails: Module needs an import attribute of type "json")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7c8fdccc8832dbf45fbf9b4d20ced