### PR TITLE
feat: expand configuration options

### DIFF
--- a/frontend/src/app/components/config/config.component.html
+++ b/frontend/src/app/components/config/config.component.html
@@ -26,6 +26,20 @@
       <mat-card>
         <mat-card-title>Shadow</mat-card-title>
         <mat-card-content>
+          <mat-slide-toggle formControlName="enabled">Enabled</mat-slide-toggle>
+          <mat-form-field>
+            <mat-label>Alpha</mat-label>
+            <input matInput type="number" formControlName="alpha" />
+          </mat-form-field>
+          <mat-form-field>
+            <mat-label>Latency ms</mat-label>
+            <input matInput type="number" formControlName="latency_ms" />
+          </mat-form-field>
+          <mat-slide-toggle formControlName="post_only_reject">Post only reject</mat-slide-toggle>
+          <mat-form-field>
+            <mat-label>Market slippage bps</mat-label>
+            <input matInput type="number" formControlName="market_slippage_bps" />
+          </mat-form-field>
           <mat-form-field>
             <mat-label>REST base</mat-label>
             <input matInput formControlName="rest_base" [matTooltip]="tips.rest_base" />
@@ -50,6 +64,16 @@
             <mat-radio-button value="light" [matTooltip]="tips.theme_light">Light</mat-radio-button>
             <mat-radio-button value="dark" [matTooltip]="tips.theme_dark">Dark</mat-radio-button>
           </mat-radio-group>
+        </mat-card-content>
+      </mat-card>
+    </div>
+
+    <div formGroupName="features">
+      <mat-card>
+        <mat-card-title>Features</mat-card-title>
+        <mat-card-content>
+          <mat-slide-toggle formControlName="risk_protections">Risk protections</mat-slide-toggle>
+          <mat-slide-toggle formControlName="market_widget_feed">Market widget feed</mat-slide-toggle>
         </mat-card-content>
       </mat-card>
     </div>
@@ -82,17 +106,101 @@
       </mat-card>
     </div>
 
+    <div formGroupName="history">
+      <mat-card>
+        <mat-card-title>History</mat-card-title>
+        <mat-card-content>
+          <mat-form-field>
+            <mat-label>DB path</mat-label>
+            <input matInput formControlName="db_path" />
+          </mat-form-field>
+          <mat-form-field>
+            <mat-label>Retention days</mat-label>
+            <input matInput type="number" formControlName="retention_days" />
+          </mat-form-field>
+        </mat-card-content>
+      </mat-card>
+    </div>
+
+    <div formGroupName="scanner">
+      <mat-card>
+        <mat-card-title>Scanner</mat-card-title>
+        <mat-card-content>
+          <mat-slide-toggle formControlName="enabled">Enabled</mat-slide-toggle>
+          <mat-form-field>
+            <mat-label>Quote</mat-label>
+            <input matInput formControlName="quote" />
+          </mat-form-field>
+          <mat-form-field>
+            <mat-label>Min price</mat-label>
+            <input matInput type="number" formControlName="min_price" />
+          </mat-form-field>
+          <mat-form-field>
+            <mat-label>Min vol USDT 24h</mat-label>
+            <input matInput type="number" formControlName="min_vol_usdt_24h" />
+          </mat-form-field>
+          <mat-form-field>
+            <mat-label>Top by volume</mat-label>
+            <input matInput type="number" formControlName="top_by_volume" />
+          </mat-form-field>
+          <mat-form-field>
+            <mat-label>Max pairs</mat-label>
+            <input matInput type="number" formControlName="max_pairs" />
+          </mat-form-field>
+          <mat-form-field>
+            <mat-label>Min spread bps</mat-label>
+            <input matInput type="number" formControlName="min_spread_bps" />
+          </mat-form-field>
+          <mat-form-field>
+            <mat-label>Vol bars</mat-label>
+            <input matInput type="number" formControlName="vol_bars" />
+          </mat-form-field>
+          <div formGroupName="score">
+            <mat-form-field>
+              <mat-label>w_spread</mat-label>
+              <input matInput type="number" formControlName="w_spread" />
+            </mat-form-field>
+            <mat-form-field>
+              <mat-label>w_vol</mat-label>
+              <input matInput type="number" formControlName="w_vol" />
+            </mat-form-field>
+          </div>
+          <mat-form-field>
+            <mat-label>Whitelist (comma separated)</mat-label>
+            <textarea matInput formControlName="whitelist"></textarea>
+          </mat-form-field>
+          <mat-form-field>
+            <mat-label>Blacklist (comma separated)</mat-label>
+            <textarea matInput formControlName="blacklist"></textarea>
+          </mat-form-field>
+        </mat-card-content>
+      </mat-card>
+    </div>
+
     <div formGroupName="strategy">
       <mat-card>
         <mat-card-title>Strategy</mat-card-title>
         <mat-card-content>
           <mat-form-field>
-            <mat-label>Symbol</mat-label>
-            <input matInput formControlName="symbol" [matTooltip]="tips.symbol" />
+            <mat-label>Name</mat-label>
+            <input matInput formControlName="name" />
           </mat-form-field>
           <div formGroupName="market_maker">
-            <mat-slide-toggle formControlName="aggressive_take" [matTooltip]="tips.aggressive_take">Aggressive take</mat-slide-toggle>
+            <mat-form-field>
+              <mat-label>Symbol</mat-label>
+              <input matInput formControlName="symbol" [matTooltip]="tips.symbol" />
+            </mat-form-field>
+            <mat-form-field>
+              <mat-label>Quote size</mat-label>
+              <input matInput type="number" formControlName="quote_size" />
+            </mat-form-field>
             <mat-slider formControlName="capital_usage" min="0" max="1" step="0.1" thumbLabel [matTooltip]="tips.capital_usage"></mat-slider>
+            <mat-form-field>
+              <mat-label>Min spread %</mat-label>
+              <input matInput type="number" formControlName="min_spread_pct" />
+            </mat-form-field>
+            <mat-slide-toggle formControlName="post_only">Post only</mat-slide-toggle>
+            <mat-slide-toggle formControlName="aggressive_take" [matTooltip]="tips.aggressive_take">Aggressive take</mat-slide-toggle>
           </div>
         </mat-card-content>
       </mat-card>

--- a/frontend/src/app/models.ts
+++ b/frontend/src/app/models.ts
@@ -14,6 +14,11 @@ export interface Config {
     [key: string]: unknown;
   };
   shadow?: {
+    enabled?: boolean;
+    alpha?: number;
+    latency_ms?: number;
+    post_only_reject?: boolean;
+    market_slippage_bps?: number;
     rest_base?: string;
     ws_base?: string;
     [key: string]: unknown;
@@ -21,6 +26,11 @@ export interface Config {
   ui?: {
     chart?: string;
     theme?: string;
+    [key: string]: unknown;
+  };
+  features?: {
+    risk_protections?: boolean;
+    market_widget_feed?: boolean;
     [key: string]: unknown;
   };
   risk?: {
@@ -31,13 +41,62 @@ export interface Config {
     min_trades_for_dd?: number;
     [key: string]: unknown;
   };
-  strategy?: {
-    symbol?: string;
-    market_maker?: {
-      aggressive_take?: boolean;
-      capital_usage?: number;
+  history?: {
+    db_path?: string;
+    retention_days?: number;
+    [key: string]: unknown;
+  };
+  scanner?: {
+    enabled?: boolean;
+    quote?: string;
+    min_price?: number;
+    min_vol_usdt_24h?: number;
+    top_by_volume?: number;
+    max_pairs?: number;
+    min_spread_bps?: number;
+    vol_bars?: number;
+    score?: {
+      w_spread?: number;
+      w_vol?: number;
       [key: string]: unknown;
     };
+    whitelist?: string[];
+    blacklist?: string[];
+    [key: string]: unknown;
+  };
+  strategy?: {
+    name?: string;
+    market_maker?: {
+      symbol?: string;
+      quote_size?: number;
+      capital_usage?: number;
+      min_spread_pct?: number;
+      cancel_timeout?: number;
+      reorder_interval?: number;
+      loop_sleep?: number;
+      depth_level?: number;
+      maker_fee_pct?: number;
+      taker_fee_pct?: number;
+      econ?: {
+        min_net_pct?: number;
+        [key: string]: unknown;
+      };
+      post_only?: boolean;
+      aggressive_take?: boolean;
+      aggressive_bps?: number;
+      inventory_target?: number;
+      inventory_tolerance?: number;
+      allow_short?: boolean;
+      status_poll_interval?: number;
+      stats_interval?: number;
+      ws_timeout?: number;
+      bootstrap_on_idle?: boolean;
+      rest_bootstrap_interval?: number;
+      plan_log_interval?: number;
+      paper_cash?: number;
+      [key: string]: unknown;
+    };
+    trend_follow?: Record<string, unknown>;
     [key: string]: unknown;
   };
   [key: string]: unknown;


### PR DESCRIPTION
## Summary
- mirror backend runtime config sections in frontend models
- expose new configuration groups in form and template
- support scanner list fields and defaults

## Testing
- `npm run lint --prefix frontend` *(fails: Module needs an import attribute of type "json")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7cabb9a64832d89f3df2870f7c98f