### PR TITLE
feat: group config settings into panels

### DIFF
--- a/frontend/src/app/components/config/config.component.html
+++ b/frontend/src/app/components/config/config.component.html
@@ -11,200 +11,225 @@
   <div *ngIf="err" class="err" style="margin-top:8px">{{ err }}</div>
 
   <form [formGroup]="cfgForm">
-    <div formGroupName="api">
-      <mat-card>
-        <mat-card-title>API</mat-card-title>
-        <mat-card-content>
-          <mat-slide-toggle formControlName="paper" [matTooltip]="tips.paper">Paper</mat-slide-toggle>
-          <mat-slide-toggle formControlName="shadow" [matTooltip]="tips.shadow">Shadow</mat-slide-toggle>
-          <mat-slide-toggle formControlName="autostart" [matTooltip]="tips.autostart">Autostart</mat-slide-toggle>
-        </mat-card-content>
-      </mat-card>
-    </div>
+    <mat-accordion>
+      <mat-expansion-panel>
+        <mat-expansion-panel-header>
+          <mat-panel-title>API</mat-panel-title>
+        </mat-expansion-panel-header>
 
-    <div formGroupName="shadow">
-      <mat-card>
-        <mat-card-title>Shadow</mat-card-title>
-        <mat-card-content>
-          <mat-slide-toggle formControlName="enabled">Enabled</mat-slide-toggle>
-          <mat-form-field>
-            <mat-label>Alpha</mat-label>
-            <input matInput type="number" formControlName="alpha" />
-          </mat-form-field>
-          <mat-form-field>
-            <mat-label>Latency ms</mat-label>
-            <input matInput type="number" formControlName="latency_ms" />
-          </mat-form-field>
-          <mat-slide-toggle formControlName="post_only_reject">Post only reject</mat-slide-toggle>
-          <mat-form-field>
-            <mat-label>Market slippage bps</mat-label>
-            <input matInput type="number" formControlName="market_slippage_bps" />
-          </mat-form-field>
-          <mat-form-field>
-            <mat-label>REST base</mat-label>
-            <input matInput formControlName="rest_base" [matTooltip]="tips.rest_base" />
-          </mat-form-field>
-          <mat-form-field>
-            <mat-label>WS base</mat-label>
-            <input matInput formControlName="ws_base" [matTooltip]="tips.ws_base" />
-          </mat-form-field>
-        </mat-card-content>
-      </mat-card>
-    </div>
+        <div formGroupName="api">
+          <mat-card>
+            <mat-card-title>API</mat-card-title>
+            <mat-card-content>
+              <mat-slide-toggle formControlName="paper" [matTooltip]="tips.paper">Paper</mat-slide-toggle>
+              <mat-slide-toggle formControlName="shadow" [matTooltip]="tips.shadow">Shadow</mat-slide-toggle>
+              <mat-slide-toggle formControlName="autostart" [matTooltip]="tips.autostart">Autostart</mat-slide-toggle>
+            </mat-card-content>
+          </mat-card>
+        </div>
 
-    <div formGroupName="ui">
-      <mat-card>
-        <mat-card-title>UI</mat-card-title>
-        <mat-card-content>
-          <mat-form-field>
-            <mat-label>Chart</mat-label>
-            <input matInput formControlName="chart" [matTooltip]="tips.chart" />
-          </mat-form-field>
-          <mat-radio-group formControlName="theme">
-            <mat-radio-button value="light" [matTooltip]="tips.theme_light">Light</mat-radio-button>
-            <mat-radio-button value="dark" [matTooltip]="tips.theme_dark">Dark</mat-radio-button>
-          </mat-radio-group>
-        </mat-card-content>
-      </mat-card>
-    </div>
+        <div formGroupName="shadow">
+          <mat-card>
+            <mat-card-title>Shadow</mat-card-title>
+            <mat-card-content>
+              <mat-slide-toggle formControlName="enabled">Enabled</mat-slide-toggle>
+              <mat-form-field>
+                <mat-label>Alpha</mat-label>
+                <input matInput type="number" formControlName="alpha" />
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label>Latency ms</mat-label>
+                <input matInput type="number" formControlName="latency_ms" />
+              </mat-form-field>
+              <mat-slide-toggle formControlName="post_only_reject">Post only reject</mat-slide-toggle>
+              <mat-form-field>
+                <mat-label>Market slippage bps</mat-label>
+                <input matInput type="number" formControlName="market_slippage_bps" />
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label>REST base</mat-label>
+                <input matInput formControlName="rest_base" [matTooltip]="tips.rest_base" />
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label>WS base</mat-label>
+                <input matInput formControlName="ws_base" [matTooltip]="tips.ws_base" />
+              </mat-form-field>
+            </mat-card-content>
+          </mat-card>
+        </div>
+      </mat-expansion-panel>
 
-    <div formGroupName="features">
-      <mat-card>
-        <mat-card-title>Features</mat-card-title>
-        <mat-card-content>
-          <mat-slide-toggle formControlName="risk_protections">Risk protections</mat-slide-toggle>
-          <mat-slide-toggle formControlName="market_widget_feed">Market widget feed</mat-slide-toggle>
-        </mat-card-content>
-      </mat-card>
-    </div>
+      <mat-expansion-panel>
+        <mat-expansion-panel-header>
+          <mat-panel-title>UI</mat-panel-title>
+        </mat-expansion-panel-header>
 
-    <div formGroupName="risk">
-      <mat-card>
-        <mat-card-title>Risk</mat-card-title>
-        <mat-card-content>
-          <mat-form-field>
-            <mat-label>Max drawdown %</mat-label>
-            <input matInput type="number" formControlName="max_drawdown_pct" [matTooltip]="tips.max_drawdown_pct" />
-          </mat-form-field>
-          <mat-form-field>
-            <mat-label>DD window sec</mat-label>
-            <input matInput type="number" formControlName="dd_window_sec" [matTooltip]="tips.dd_window_sec" />
-          </mat-form-field>
-          <mat-form-field>
-            <mat-label>Stop duration sec</mat-label>
-            <input matInput type="number" formControlName="stop_duration_sec" [matTooltip]="tips.stop_duration_sec" />
-          </mat-form-field>
-          <mat-form-field>
-            <mat-label>Cooldown sec</mat-label>
-            <input matInput type="number" formControlName="cooldown_sec" [matTooltip]="tips.cooldown_sec" />
-          </mat-form-field>
-          <mat-form-field>
-            <mat-label>Min trades for DD</mat-label>
-            <input matInput type="number" formControlName="min_trades_for_dd" [matTooltip]="tips.min_trades_for_dd" />
-          </mat-form-field>
-        </mat-card-content>
-      </mat-card>
-    </div>
+        <div formGroupName="ui">
+          <mat-card>
+            <mat-card-title>UI</mat-card-title>
+            <mat-card-content>
+              <mat-form-field>
+                <mat-label>Chart</mat-label>
+                <input matInput formControlName="chart" [matTooltip]="tips.chart" />
+              </mat-form-field>
+              <mat-radio-group formControlName="theme">
+                <mat-radio-button value="light" [matTooltip]="tips.theme_light">Light</mat-radio-button>
+                <mat-radio-button value="dark" [matTooltip]="tips.theme_dark">Dark</mat-radio-button>
+              </mat-radio-group>
+            </mat-card-content>
+          </mat-card>
+        </div>
 
-    <div formGroupName="history">
-      <mat-card>
-        <mat-card-title>History</mat-card-title>
-        <mat-card-content>
-          <mat-form-field>
-            <mat-label>DB path</mat-label>
-            <input matInput formControlName="db_path" />
-          </mat-form-field>
-          <mat-form-field>
-            <mat-label>Retention days</mat-label>
-            <input matInput type="number" formControlName="retention_days" />
-          </mat-form-field>
-        </mat-card-content>
-      </mat-card>
-    </div>
+        <div formGroupName="features">
+          <mat-card>
+            <mat-card-title>Features</mat-card-title>
+            <mat-card-content>
+              <mat-slide-toggle formControlName="risk_protections">Risk protections</mat-slide-toggle>
+              <mat-slide-toggle formControlName="market_widget_feed">Market widget feed</mat-slide-toggle>
+            </mat-card-content>
+          </mat-card>
+        </div>
+      </mat-expansion-panel>
 
-    <div formGroupName="scanner">
-      <mat-card>
-        <mat-card-title>Scanner</mat-card-title>
-        <mat-card-content>
-          <mat-slide-toggle formControlName="enabled">Enabled</mat-slide-toggle>
-          <mat-form-field>
-            <mat-label>Quote</mat-label>
-            <input matInput formControlName="quote" />
-          </mat-form-field>
-          <mat-form-field>
-            <mat-label>Min price</mat-label>
-            <input matInput type="number" formControlName="min_price" />
-          </mat-form-field>
-          <mat-form-field>
-            <mat-label>Min vol USDT 24h</mat-label>
-            <input matInput type="number" formControlName="min_vol_usdt_24h" />
-          </mat-form-field>
-          <mat-form-field>
-            <mat-label>Top by volume</mat-label>
-            <input matInput type="number" formControlName="top_by_volume" />
-          </mat-form-field>
-          <mat-form-field>
-            <mat-label>Max pairs</mat-label>
-            <input matInput type="number" formControlName="max_pairs" />
-          </mat-form-field>
-          <mat-form-field>
-            <mat-label>Min spread bps</mat-label>
-            <input matInput type="number" formControlName="min_spread_bps" />
-          </mat-form-field>
-          <mat-form-field>
-            <mat-label>Vol bars</mat-label>
-            <input matInput type="number" formControlName="vol_bars" />
-          </mat-form-field>
-          <div formGroupName="score">
-            <mat-form-field>
-              <mat-label>w_spread</mat-label>
-              <input matInput type="number" formControlName="w_spread" />
-            </mat-form-field>
-            <mat-form-field>
-              <mat-label>w_vol</mat-label>
-              <input matInput type="number" formControlName="w_vol" />
-            </mat-form-field>
-          </div>
-          <mat-form-field>
-            <mat-label>Whitelist (comma separated)</mat-label>
-            <textarea matInput formControlName="whitelist"></textarea>
-          </mat-form-field>
-          <mat-form-field>
-            <mat-label>Blacklist (comma separated)</mat-label>
-            <textarea matInput formControlName="blacklist"></textarea>
-          </mat-form-field>
-        </mat-card-content>
-      </mat-card>
-    </div>
+      <mat-expansion-panel>
+        <mat-expansion-panel-header>
+          <mat-panel-title>Risk</mat-panel-title>
+        </mat-expansion-panel-header>
 
-    <div formGroupName="strategy">
-      <mat-card>
-        <mat-card-title>Strategy</mat-card-title>
-        <mat-card-content>
-          <mat-form-field>
-            <mat-label>Name</mat-label>
-            <input matInput formControlName="name" />
-          </mat-form-field>
-          <div formGroupName="market_maker">
-            <mat-form-field>
-              <mat-label>Symbol</mat-label>
-              <input matInput formControlName="symbol" [matTooltip]="tips.symbol" />
-            </mat-form-field>
-            <mat-form-field>
-              <mat-label>Quote size</mat-label>
-              <input matInput type="number" formControlName="quote_size" />
-            </mat-form-field>
-            <mat-slider formControlName="capital_usage" min="0" max="1" step="0.1" thumbLabel [matTooltip]="tips.capital_usage"></mat-slider>
-            <mat-form-field>
-              <mat-label>Min spread %</mat-label>
-              <input matInput type="number" formControlName="min_spread_pct" />
-            </mat-form-field>
-            <mat-slide-toggle formControlName="post_only">Post only</mat-slide-toggle>
-            <mat-slide-toggle formControlName="aggressive_take" [matTooltip]="tips.aggressive_take">Aggressive take</mat-slide-toggle>
-          </div>
-        </mat-card-content>
-      </mat-card>
-    </div>
+        <div formGroupName="risk">
+          <mat-card>
+            <mat-card-title>Risk</mat-card-title>
+            <mat-card-content>
+              <mat-form-field>
+                <mat-label>Max drawdown %</mat-label>
+                <input matInput type="number" formControlName="max_drawdown_pct" [matTooltip]="tips.max_drawdown_pct" />
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label>DD window sec</mat-label>
+                <input matInput type="number" formControlName="dd_window_sec" [matTooltip]="tips.dd_window_sec" />
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label>Stop duration sec</mat-label>
+                <input matInput type="number" formControlName="stop_duration_sec" [matTooltip]="tips.stop_duration_sec" />
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label>Cooldown sec</mat-label>
+                <input matInput type="number" formControlName="cooldown_sec" [matTooltip]="tips.cooldown_sec" />
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label>Min trades for DD</mat-label>
+                <input matInput type="number" formControlName="min_trades_for_dd" [matTooltip]="tips.min_trades_for_dd" />
+              </mat-form-field>
+            </mat-card-content>
+          </mat-card>
+        </div>
+
+        <div formGroupName="history">
+          <mat-card>
+            <mat-card-title>History</mat-card-title>
+            <mat-card-content>
+              <mat-form-field>
+                <mat-label>DB path</mat-label>
+                <input matInput formControlName="db_path" />
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label>Retention days</mat-label>
+                <input matInput type="number" formControlName="retention_days" />
+              </mat-form-field>
+            </mat-card-content>
+          </mat-card>
+        </div>
+      </mat-expansion-panel>
+
+      <mat-expansion-panel>
+        <mat-expansion-panel-header>
+          <mat-panel-title>Strategy</mat-panel-title>
+        </mat-expansion-panel-header>
+
+        <div formGroupName="scanner">
+          <mat-card>
+            <mat-card-title>Scanner</mat-card-title>
+            <mat-card-content>
+              <mat-slide-toggle formControlName="enabled">Enabled</mat-slide-toggle>
+              <mat-form-field>
+                <mat-label>Quote</mat-label>
+                <input matInput formControlName="quote" />
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label>Min price</mat-label>
+                <input matInput type="number" formControlName="min_price" />
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label>Min vol USDT 24h</mat-label>
+                <input matInput type="number" formControlName="min_vol_usdt_24h" />
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label>Top by volume</mat-label>
+                <input matInput type="number" formControlName="top_by_volume" />
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label>Max pairs</mat-label>
+                <input matInput type="number" formControlName="max_pairs" />
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label>Min spread bps</mat-label>
+                <input matInput type="number" formControlName="min_spread_bps" />
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label>Vol bars</mat-label>
+                <input matInput type="number" formControlName="vol_bars" />
+              </mat-form-field>
+              <div formGroupName="score">
+                <mat-form-field>
+                  <mat-label>w_spread</mat-label>
+                  <input matInput type="number" formControlName="w_spread" />
+                </mat-form-field>
+                <mat-form-field>
+                  <mat-label>w_vol</mat-label>
+                  <input matInput type="number" formControlName="w_vol" />
+                </mat-form-field>
+              </div>
+              <mat-form-field>
+                <mat-label>Whitelist (comma separated)</mat-label>
+                <textarea matInput formControlName="whitelist"></textarea>
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label>Blacklist (comma separated)</mat-label>
+                <textarea matInput formControlName="blacklist"></textarea>
+              </mat-form-field>
+            </mat-card-content>
+          </mat-card>
+        </div>
+
+        <div formGroupName="strategy">
+          <mat-card>
+            <mat-card-title>Strategy</mat-card-title>
+            <mat-card-content>
+              <mat-form-field>
+                <mat-label>Name</mat-label>
+                <input matInput formControlName="name" />
+              </mat-form-field>
+              <div formGroupName="market_maker">
+                <mat-form-field>
+                  <mat-label>Symbol</mat-label>
+                  <input matInput formControlName="symbol" [matTooltip]="tips.symbol" />
+                </mat-form-field>
+                <mat-form-field>
+                  <mat-label>Quote size</mat-label>
+                  <input matInput type="number" formControlName="quote_size" />
+                </mat-form-field>
+                <mat-slider formControlName="capital_usage" min="0" max="1" step="0.1" thumbLabel [matTooltip]="tips.capital_usage"></mat-slider>
+                <mat-form-field>
+                  <mat-label>Min spread %</mat-label>
+                  <input matInput type="number" formControlName="min_spread_pct" />
+                </mat-form-field>
+                <mat-slide-toggle formControlName="post_only">Post only</mat-slide-toggle>
+                <mat-slide-toggle formControlName="aggressive_take" [matTooltip]="tips.aggressive_take">Aggressive take</mat-slide-toggle>
+              </div>
+            </mat-card-content>
+          </mat-card>
+        </div>
+      </mat-expansion-panel>
+    </mat-accordion>
   </form>
 </div>
-

--- a/frontend/src/app/components/config/config.component.ts
+++ b/frontend/src/app/components/config/config.component.ts
@@ -9,6 +9,7 @@ import { MatRadioModule } from '@angular/material/radio';
 import { MatSliderModule } from '@angular/material/slider';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatExpansionModule } from '@angular/material/expansion';
 
 @Component({
   selector: 'app-config',
@@ -21,6 +22,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     MatSliderModule,
     MatFormFieldModule,
     MatTooltipModule,
+    MatExpansionModule,
   ],
   templateUrl: './config.component.html',
   styleUrls: ['./config.component.css'],


### PR DESCRIPTION
## Summary
- group API, UI, Risk, and Strategy settings into expansion panels for clearer organization
- enable Angular expansion panel usage in Config component

## Testing
- `NODE_OPTIONS=--experimental-json-modules npm run lint` *(fails: TypeError [ERR_IMPORT_ASSERTION_TYPE_MISSING])* 
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7cfca9e30832da6aacc8b1a45d4fd