### PR TITLE
refactor: tidy config router imports

### DIFF
--- a/backend/app/api/routers/config.py
+++ b/backend/app/api/routers/config.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from fastapi import APIRouter, Request, HTTPException
-from fastapi.responses import JSONResponse
 
 from ...core.config import settings
 from ...services.state import get_state


### PR DESCRIPTION
## Summary
- remove unused JSONResponse import
- streamline typing imports in config router

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7e21e8d18832da65354302ab999f5