### PR TITLE
style: reorder risk imports

### DIFF
--- a/backend/app/api/routers/risk.py
+++ b/backend/app/api/routers/risk.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
-import time
 import logging
+import time
 from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, HTTPException


### PR DESCRIPTION
## Summary
- reorder top-level imports in `risk.py` so logging precedes time

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7e29840f0832d8c8b2cb1f7e5c99a