### PR TITLE
Handle zero step in round_step

### DIFF
--- a/backend/app/services/utils.py
+++ b/backend/app/services/utils.py
@@ -1,6 +1,8 @@
 from decimal import Decimal, ROUND_DOWN, ROUND_UP
 
 def round_step(value: float, step: float, precision: int = 8) -> float:
+    if step == 0:
+        return float(value)
     v = Decimal(str(value)); s = Decimal(str(step))
     q = (v // s) * s
     return float(q.quantize(Decimal(10) ** -precision, rounding=ROUND_DOWN))


### PR DESCRIPTION
## Summary
- avoid division errors by returning value when round_step is called with a zero step

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7e36cdf00832da18d51367fc17f64