### PR TITLE
Reset panic flag and add panic sell button

### DIFF
--- a/backend/app/services/state.py
+++ b/backend/app/services/state.py
@@ -172,6 +172,7 @@ class AppState:
             logger.exception("Failed to dump balances")
 
         await self.stop_bot()
+        self._panic_triggered = False
 
     async def handle_cmd(self, cmd: str, save: bool = False) -> None:
         c = (cmd or "").lower()

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -48,3 +48,9 @@
         <app-equity-sparkline></app-equity-sparkline>
     </div>
 </div>
+
+<div class="grid" style="margin-top:12px">
+    <div class="cell" style="grid-column: span 3; text-align:center;">
+        <button mat-raised-button color="warn" (click)="panicSell()" [disabled]="!running">PANIC SELL</button>
+    </div>
+</div>

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -6,6 +6,7 @@ import { BotStatus } from '../../models';
 import { WsService } from '../../services/ws.service';
 import { Subscription } from 'rxjs';
 import { EquitySparklineComponent } from '../equity-sparkline/equity-sparkline.component'; // ⬅️ импорт спарклайна
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 interface WsStats { ws_clients: number; ws_rate: number; }
 interface MarketSnap { symbol?: string; bid?: number; ask?: number; last?: number; ts?: number; raw?: any; }
@@ -29,7 +30,7 @@ export class DashboardComponent implements OnDestroy {
 
   private sub = new Subscription();
 
-  constructor(private api: ApiService, private wsSvc: WsService) {
+  constructor(private api: ApiService, private wsSvc: WsService, private snack: MatSnackBar) {
     this.refreshStatus();
     this.bindWs();
   }
@@ -88,5 +89,13 @@ export class DashboardComponent implements OnDestroy {
           }
         })
     );
+  }
+
+  panicSell() {
+    if (!window.confirm('Выполнить PANIC SELL?')) return;
+    this.api.cmd('x').subscribe({
+      next: _ => this.snack.open('Panic sell executed', 'OK', { duration: 2000 }),
+      error: err => this.snack.open(`Ошибка: ${err?.error?.error || err?.message || 'unknown'}`, 'OK', { duration: 2500 })
+    });
   }
 }


### PR DESCRIPTION
## Summary
- Reset panic flag after panic sell completes so future triggers are allowed
- Add PANIC SELL button to dashboard to trigger emergency liquidation

## Testing
- `pytest`
- `npm test -- --watch=false --browsers=ChromeHeadless` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b7e4131724832d9d297be30b0a2d92