### PR TITLE
chore: set default backend port to 8100

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Pydantic 2.11+.
 
 > **Note**: building the frontend requires **Node.js 20+**.
 
+By default the FastAPI server listens on port **8100** and the Angular development server runs on port **4400**.
+
 ## Authentication
 
 All API and WebSocket endpoints require a static bearer token.
@@ -14,7 +16,7 @@ All API and WebSocket endpoints require a static bearer token.
 1. **Configure backend** – set the token via environment variable:
    ```bash
    export API_TOKEN="your-secret"
-   uvicorn app.main:app --host 0.0.0.0 --port 8000
+   uvicorn app.main:app --host 0.0.0.0 --port 8100
    ```
 
 2. **Frontend** – expose the same token to the browser via `window.__TOKEN__` (and optionally `window.__WS__` for a custom WebSocket URL). The API base URL is configured in `src/environments/environment.ts`. The Angular `ApiService` automatically sends the token in the `Authorization: Bearer` header and the `WsService` appends it as a `token` query parameter.
@@ -34,13 +36,13 @@ credentials via environment variables before launching the backend:
 ```bash
 export BINANCE_API_KEY="your_key"
 export BINANCE_API_SECRET="your_secret"
-uvicorn app.main:app --host 0.0.0.0 --port 8000
+uvicorn app.main:app --host 0.0.0.0 --port 8100
 ```
 
 Then call the scanner endpoint:
 
 ```bash
-curl -X POST "http://localhost:8000/scanner/scan" \
+curl -X POST "http://localhost:8100/scanner/scan" \
      -H "Authorization: Bearer $API_TOKEN" \
      -H "Content-Type: application/json" \
      -d '{}'

--- a/backend/README.md
+++ b/backend/README.md
@@ -7,7 +7,7 @@ Pydantic 2.11+.
 ```bash
 python3.12 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
-uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+uvicorn app.main:app --host 0.0.0.0 --port 8100 --reload
 ```
 
 ## ENV

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -138,7 +138,7 @@ class AppSettings(BaseSettings):
     )
 
     app_host: str = Field("0.0.0.0", alias="APP_HOST")
-    app_port: int = Field(8000, alias="APP_PORT")
+    app_port: int = Field(8100, alias="APP_PORT")
     app_reload: bool = Field(False, alias="APP_RELOAD")
     app_origins: str = Field("*", alias="APP_ORIGINS")
 


### PR DESCRIPTION
## Summary
- default backend APP_PORT to 8100
- document backend 8100 and frontend 4400 ports in READMEs

## Testing
- `black backend/app/core/config.py`
- `flake8 backend` *(fails: E302 expected 2 blank lines, found 1, ...)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7e546f934832daa9984f6d2421b30