### PR TITLE
chore: remove unused starlette import

### DIFF
--- a/backend/app/services/history.py
+++ b/backend/app/services/history.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, Optional, Tuple
 
 import aiosqlite
-from starlette.concurrency import iterate_in_threadpool
 
 DATA_DIR = Path(__file__).resolve().parents[2] / "data"
 DATA_DIR.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- remove unneeded iterate_in_threadpool import from history service

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7e66a6944832d9c005d3051ebc886