### PR TITLE
Ensure panic flag resets after panic sell

### DIFF
--- a/backend/app/services/state.py
+++ b/backend/app/services/state.py
@@ -171,8 +171,10 @@ class AppState:
         except Exception:
             logger.exception("Failed to dump balances")
 
-        await self.stop_bot()
-        self._panic_triggered = False
+        try:
+            await self.stop_bot()
+        finally:
+            self._panic_triggered = False
 
     async def handle_cmd(self, cmd: str, save: bool = False) -> None:
         c = (cmd or "").lower()


### PR DESCRIPTION
## Summary
- ensure panic flag resets even if stopping the bot raises

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7e918114c832d9918396ae92f1cf2