### PR TITLE
Use constant-time token comparison

### DIFF
--- a/backend/app/api/routers/ws.py
+++ b/backend/app/api/routers/ws.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import secrets
 from typing import Any, Callable, Optional
 import logging
 
@@ -86,7 +87,7 @@ def _subscribe(state: Any) -> tuple[asyncio.Queue, Callable[[], None]]:
 async def ws_stream(ws: WebSocket):
     """Стрим событий в UI. Устойчив к отключениям и shutdown."""
     token = ws.query_params.get("token")
-    if token != settings.api_token:
+    if not token or not secrets.compare_digest(token, settings.api_token or ""):
         await ws.close(code=1008, reason="Invalid token")
         return
 

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import secrets
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from .services.state import AppState, get_state
@@ -11,5 +12,5 @@ security = HTTPBearer(auto_error=False)
 
 def auth_dep(credentials: HTTPAuthorizationCredentials = Depends(security)) -> None:
     token = credentials.credentials if credentials else None
-    if not token or token != settings.api_token:
+    if not token or not secrets.compare_digest(token, settings.api_token or ""):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or missing token")


### PR DESCRIPTION
## Summary
- Secure token validation in WebSocket and auth dependency using `secrets.compare_digest`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7ea64b38c832dbf357db49f509f91