### PR TITLE
refactor: modularize state services

### DIFF
--- a/backend/app/services/configuration.py
+++ b/backend/app/services/configuration.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Mapping
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigService:
+    """Utility class for application runtime configuration."""
+
+    def __init__(self, raw: Any | None = None) -> None:
+        self.cfg: Dict[str, Any] = self.coerce_cfg(raw)
+
+    @staticmethod
+    def coerce_cfg(raw: Any) -> Dict[str, Any]:
+        if raw is None:
+            return {}
+        if isinstance(raw, dict):
+            return raw
+        if isinstance(raw, Mapping):
+            return dict(raw)
+        if isinstance(raw, str):
+            try:
+                data = yaml.safe_load(raw) or {}
+                if isinstance(data, dict):
+                    return data
+                return {"_raw": raw, "_parsed": data}
+            except Exception as e:  # pragma: no cover - safe load errors
+                logger.warning("cfg safe_load failed: %s", e)
+                return {"_raw": raw}
+        return {}
+
+    def set_cfg(self, new_cfg: Any) -> Dict[str, Any]:
+        self.cfg = self.coerce_cfg(new_cfg)
+        logger.info("Config updated. keys=%s", list(self.cfg.keys())[:8])
+        return self.cfg

--- a/backend/app/services/events.py
+++ b/backend/app/services/events.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import asdict, is_dataclass
+from typing import Any, Mapping
+
+logger = logging.getLogger(__name__)
+
+
+class EventDispatcher:
+    """Dispatch incoming events to dedicated handlers."""
+
+    def __init__(self, state: "AppState") -> None:
+        self.state = state
+        self._handlers = [
+            self._handle_risk,
+            self._handle_history,
+            self._handle_market,
+            self._handle_misc,
+        ]
+
+    async def dispatch(self, evt: Any) -> None:
+        try:
+            if not isinstance(evt, dict):
+                if hasattr(evt, "dict"):
+                    evt = evt.dict()
+                elif is_dataclass(evt):
+                    evt = asdict(evt)
+                elif isinstance(evt, Mapping):
+                    evt = dict(evt)
+                else:
+                    self.state.broadcast("diag", text=str(evt))
+                    return
+        except Exception:
+            self.state.broadcast("diag", text=str(evt))
+            return
+
+        for handler in self._handlers:
+            if await handler(evt):
+                return
+
+    # --- handlers ----------------------------------------------------------
+    async def _handle_risk(self, evt: dict) -> bool:
+        try:
+            t_tmp = evt.get("type")
+            eq_val = evt.get("equity", None)
+            if t_tmp == "equity" and eq_val is None:
+                eq_val = evt.get("value", None)
+            if eq_val is not None:
+                self.state.on_equity(float(eq_val))
+        except Exception:
+            logger.exception("Failed to handle equity value from event")
+        return False
+
+    async def _handle_history(self, evt: dict) -> bool:
+        t = evt.get("type")
+        try:
+            if t == "order_event" and getattr(self.state, "history", None):
+                await self.state.history.log_order_event(evt)
+            elif t in {"trade", "fill"} and getattr(self.state, "history", None):
+                await self.state.history.log_trade(evt)
+                pnl = float(evt.get("pnl") or 0.0) if isinstance(evt.get("pnl"), (int, float, str)) else 0.0
+                self.state.on_trade_closed(pair=str(evt.get("symbol") or ""), pnl=pnl)
+        except Exception:
+            logger.exception("history log failed")
+        return False
+
+    async def _handle_market(self, evt: dict) -> bool:
+        t = evt.get("type")
+        if t in {"market", "bank", "trade", "fill", "order_event", "stats", "diag", "plan", "status"}:
+            self.state._broadcast_obj(evt)
+            return True
+        if not t and "e" in evt and "s" in evt:
+            etype = str(evt.get("e"))
+            s = str(evt.get("s"))
+            ts = evt.get("E") or int(time.time() * 1000)
+            if etype == "bookTicker" and ("b" in evt or "a" in evt):
+                self.state.broadcast("market", symbol=s, bestBid=evt.get("b"), bestAsk=evt.get("a"), ts=ts)
+                return True
+            if etype in ("24hrTicker", "24hrMiniTicker"):
+                self.state.broadcast("market", symbol=s, lastPrice=evt.get("c"), ts=ts)
+                return True
+            if etype in ("trade", "aggTrade"):
+                self.state.broadcast("market", symbol=s, lastPrice=evt.get("p"), ts=ts)
+                return True
+            if etype == "depthUpdate" and (isinstance(evt.get("b"), list) or isinstance(evt.get("a"), list)):
+                try:
+                    b0 = evt.get("b")[0][0] if evt.get("b") else None
+                except Exception:
+                    b0 = None
+                try:
+                    a0 = evt.get("a")[0][0] if evt.get("a") else None
+                except Exception:
+                    a0 = None
+                self.state.broadcast("market", symbol=s, bestBid=b0, bestAsk=a0, ts=ts)
+                return True
+        return False
+
+    async def _handle_misc(self, evt: dict) -> bool:
+        t = evt.get("type")
+        if not t:
+            self.state.broadcast("diag", text=json.dumps(evt, ensure_ascii=False))
+            return True
+        if t in {"ticker", "book", "depth"}:
+            self.state.broadcast("market", **{k: v for k, v in evt.items() if k != "type"})
+            return True
+        if t in {"balance", "pnl", "equity"}:
+            self.state.broadcast("bank", **{k: v for k, v in evt.items() if k != "type"})
+            return True
+        if t in {"log", "debug"}:
+            self.state.broadcast("diag", text=str(evt.get("msg") or evt.get("text") or ""))
+            return True
+        self.state._broadcast_obj(evt)
+        return True

--- a/backend/app/services/ws.py
+++ b/backend/app/services/ws.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import asdict, is_dataclass
+from typing import Any, Set
+from collections.abc import Mapping
+
+from ..models.schemas import BotStatus
+
+logger = logging.getLogger(__name__)
+
+
+class WSBroadcaster:
+    """Manage websocket clients and broadcast events."""
+
+    def __init__(self) -> None:
+        self._clients: Set[asyncio.Queue[str]] = set()
+        self.sent_counter = 0
+        self.sent_last_ts = time.time()
+
+    # --- client management -------------------------------------------------
+    @property
+    def clients(self) -> Set[asyncio.Queue[str]]:
+        return self._clients
+
+    def register_ws(self) -> asyncio.Queue[str]:
+        q: asyncio.Queue[str] = asyncio.Queue(maxsize=1000)
+        self._clients.add(q)
+        logger.info("WS connected. total=%d", len(self._clients))
+        return q
+
+    def unregister_ws(self, q: asyncio.Queue[str]) -> None:
+        self._clients.discard(q)
+        logger.info("WS disconnected. total=%d", len(self._clients))
+
+    def ws_subscribe(self, q: asyncio.Queue) -> callable:
+        self._clients.add(q)  # type: ignore
+        logger.info("WS connected (ext). total=%d", len(self._clients))
+
+        def _unsub():
+            try:
+                self._clients.discard(q)  # type: ignore
+                logger.info("WS disconnected (ext). total=%d", len(self._clients))
+            except Exception:
+                logger.exception("Failed to disconnect websocket client")
+
+        return _unsub
+
+    # --- broadcasting ------------------------------------------------------
+    def _broadcast_obj(self, obj: Any) -> None:
+        try:
+            if isinstance(obj, dict):
+                data = json.dumps(obj, ensure_ascii=False)
+            elif isinstance(obj, str):
+                data = obj
+            else:
+                if hasattr(obj, "model_dump"):
+                    data = json.dumps(obj.model_dump(), ensure_ascii=False)
+                elif hasattr(obj, "dict"):
+                    data = json.dumps(obj.dict(), ensure_ascii=False)
+                elif is_dataclass(obj):
+                    data = json.dumps(asdict(obj), ensure_ascii=False)
+                elif isinstance(obj, Mapping):
+                    data = json.dumps(dict(obj), ensure_ascii=False)
+                else:
+                    data = str(obj)
+        except Exception:
+            logger.exception("Failed to serialize broadcast obj, sending as text")
+            data = str(obj)
+
+        for q in list(self._clients):
+            try:
+                q.put_nowait(data)
+                self.sent_counter += 1
+            except asyncio.QueueFull:
+                self._clients.discard(q)
+
+    def broadcast(self, type_: str, **payload: Any) -> None:
+        self._broadcast_obj({"type": type_, **payload})
+
+    def broadcast_status(self, status: BotStatus) -> None:
+        try:
+            payload = status.model_dump()  # pydantic v2
+        except Exception:
+            payload = {
+                "running": status.running,
+                "symbol": status.symbol,
+                "metrics": status.metrics,
+                "cfg": status.cfg,
+            }
+        payload["type"] = "status"
+        self._broadcast_obj(payload)


### PR DESCRIPTION
## Summary
- extract `ConfigService` for runtime configuration
- add `WSBroadcaster` to manage websocket clients and broadcasting
- introduce `EventDispatcher` with dedicated market/history/risk handlers
- refactor `AppState` to use new services and simple event dispatch wrapper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7eb18328c832d8b653a50b175a363