### PR TITLE
docs: clarify default ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Pydantic 2.11+.
 
 > **Note**: building the frontend requires **Node.js 20+**.
 
-By default the FastAPI server listens on port **8100** and the Angular development server runs on port **4400**.
+By default, the FastAPI server listens on port **8100**, and the Angular development server runs on port **4400**.
 
 ## Authentication
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -10,6 +10,8 @@ pip install -r requirements.txt
 uvicorn app.main:app --host 0.0.0.0 --port 8100 --reload
 ```
 
+This starts the backend on port **8100**, matching the documentation in the project root.
+
 ## ENV
 See `.env.example`. Defaults to shadow/paper mode.
 


### PR DESCRIPTION
## Summary
- clarify that FastAPI backend runs on port 8100 and Angular dev server on 4400
- mention backend port 8100 in backend README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7ef0e918c832d88bac9bb8792a9e4