### PR TITLE
Limit orders widget rows and make table header sticky

### DIFF
--- a/frontend/src/app/components/orders-widget/orders-widget.component.html
+++ b/frontend/src/app/components/orders-widget/orders-widget.component.html
@@ -1,7 +1,6 @@
 <div class="wrap">
     <div class="head">
         <h3>Ордера (live)</h3>
-        <div class="muted">поток без лимита (храню {{maxKeep}})</div>
     </div>
 
     <div class="scroll">

--- a/frontend/src/app/components/orders-widget/orders-widget.component.scss
+++ b/frontend/src/app/components/orders-widget/orders-widget.component.scss
@@ -5,6 +5,12 @@
   font-size: 12px;
   table-layout: fixed;
 }
+.tbl thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: #0f1216;
+}
 .tbl th, .tbl td {
   border-bottom:1px solid #222;
   padding:4px 6px;

--- a/frontend/src/app/components/orders-widget/orders-widget.component.ts
+++ b/frontend/src/app/components/orders-widget/orders-widget.component.ts
@@ -20,9 +20,8 @@ interface LiveOrder {
     styleUrls: ['./orders-widget.component.scss']
 })
 export class OrdersWidgetComponent {
-    // полный поток без лимита (с удержанием разумного окна)
     orders: LiveOrder[] = [];
-    maxKeep = 500;
+    maxKeep = 100;
 
     constructor(private ws: WsService) {}
 


### PR DESCRIPTION
## Summary
- cap orders widget at 100 entries and clean up unlimited stream comment
- remove obsolete muted message in orders widget header
- keep orders table header visible during scroll with sticky styling

## Testing
- `npm run lint` *(fails: 781 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b865ec2954832da89bfb93bdc9edde