### PR TITLE
Limit logs view to most recent 100 entries

### DIFF
--- a/frontend/src/app/components/logs/logs.component.ts
+++ b/frontend/src/app/components/logs/logs.component.ts
@@ -20,7 +20,7 @@ export class LogsComponent {
     @ViewChild('pane') pane?: ElementRef<HTMLDivElement>;
 
     rows: LogRow[] = [];
-    maxRows = 2000;
+    maxRows = 100;
 
     constructor(private ws: WsService, private zone: NgZone) {}
 


### PR DESCRIPTION
## Summary
- cap log component to retain only the latest 100 messages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js'; after installing, lint reports 782 errors across codebase)*
- `npm run build`
- `node -e "const maxRows=100; const rows=[]; function onEvent(text){rows.unshift({text}); if(rows.length>maxRows) rows.splice(maxRows);} for(let i=0;i<150;i++) onEvent('msg'+i); console.log('rows length:', rows.length); console.log('first:', rows[0].text, 'last:', rows[rows.length-1].text);"`

------
https://chatgpt.com/codex/tasks/task_e_68b866092b50832db0dfaa8308c86836